### PR TITLE
fix: 참여,고마움 API 로그인 인증 적용 & 에러 커스텀

### DIFF
--- a/src/main/java/com/carpBread/shareEatIt/domain/participation/controller/GratitudeStickerController.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/participation/controller/GratitudeStickerController.java
@@ -1,5 +1,7 @@
 package com.carpBread.shareEatIt.domain.participation.controller;
 
+import com.carpBread.shareEatIt.domain.auth.AuthUser;
+import com.carpBread.shareEatIt.domain.member.entity.Member;
 import com.carpBread.shareEatIt.domain.participation.dto.GratitudeResponseDto;
 import com.carpBread.shareEatIt.domain.participation.entity.GratitudeType;
 import com.carpBread.shareEatIt.domain.participation.service.GratitudeStickerService;
@@ -17,12 +19,12 @@ public class GratitudeStickerController {
     private final GratitudeStickerService gratitudeStickerService;
 
     /* 고마움 남기기(생성) */
-    @PostMapping("/{postId}/{memberId}")
+    @PostMapping("/{postId}")
     @ResponseStatus(HttpStatus.CREATED)
-    public ResponseEntity<ApiResponse<GratitudeResponseDto>> createGratitudeSticker(@PathVariable("postId") Long postId,
-                                                                                    @PathVariable("memberId") Long memberId,
+    public ResponseEntity<ApiResponse<GratitudeResponseDto>> createGratitudeSticker(@AuthUser Member member,
+                                                                                    @PathVariable("postId") Long postId,
                                                                                     @RequestParam("gratitudeType")GratitudeType gratitudeType){
-        GratitudeResponseDto responseDto = gratitudeStickerService.createGratitudeSticker(postId, memberId, gratitudeType);
+        GratitudeResponseDto responseDto = gratitudeStickerService.createGratitudeSticker(postId, member, gratitudeType);
         ApiResponse<GratitudeResponseDto> response = new ApiResponse<>(
                 HttpStatus.CREATED.value(),  // 상태코드 201
                 "고마움 생성 성공",   // 성공 메시지
@@ -34,10 +36,10 @@ public class GratitudeStickerController {
     /* 고마움 수정하기 */
     @PatchMapping("/{gsId}/{memberId}")
     @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<ApiResponse<GratitudeResponseDto>> updateGratitudeSticker(@PathVariable("gsId") Long gratitudeStickerId,
-                                                                                    @PathVariable("memberId") Long memberId,
+    public ResponseEntity<ApiResponse<GratitudeResponseDto>> updateGratitudeSticker(@AuthUser Member member,
+                                                                                    @PathVariable("gsId") Long gratitudeStickerId,
                                                                                     @RequestParam("gratitudeType")GratitudeType gratitudeType){
-        GratitudeResponseDto responseDto = gratitudeStickerService.updateGratitudeStickers(gratitudeStickerId, memberId, gratitudeType);
+        GratitudeResponseDto responseDto = gratitudeStickerService.updateGratitudeStickers(gratitudeStickerId, member, gratitudeType);
         ApiResponse<GratitudeResponseDto> response = new ApiResponse<>(
                 HttpStatus.OK.value(),  //상태코드 200
                 "고마움 스티커 수정 성공",  // 성공 메시지

--- a/src/main/java/com/carpBread/shareEatIt/domain/participation/controller/GratitudeStickerController.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/participation/controller/GratitudeStickerController.java
@@ -34,7 +34,7 @@ public class GratitudeStickerController {
     }
 
     /* 고마움 수정하기 */
-    @PatchMapping("/{gsId}/{memberId}")
+    @PatchMapping("/{gsId}")
     @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<ApiResponse<GratitudeResponseDto>> updateGratitudeSticker(@AuthUser Member member,
                                                                                     @PathVariable("gsId") Long gratitudeStickerId,

--- a/src/main/java/com/carpBread/shareEatIt/domain/participation/controller/ParticipationController.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/participation/controller/ParticipationController.java
@@ -67,10 +67,10 @@ public class ParticipationController {
     // 참여 테이블의 참여 상태 변경
     @PatchMapping("/{ptId}")
     @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<ApiResponse<ParticipationUpdateStatusResponseDto>> updateStatus(@AuthUser Member receiver,
+    public ResponseEntity<ApiResponse<ParticipationUpdateStatusResponseDto>> updateStatus(@AuthUser Member giver,
                                                                                           @PathVariable("ptId") Long ptId,
                                                                                           @RequestParam("status") ParticipationStatus status){
-        ParticipationUpdateStatusResponseDto responseDto = participationService.updateStatus(ptId,receiver,status);
+        ParticipationUpdateStatusResponseDto responseDto = participationService.updateStatus(ptId, giver, status);
         ApiResponse<ParticipationUpdateStatusResponseDto> response = new ApiResponse<>(
                 HttpStatus.OK.value(),  // 상태코드 200
                 "참여 상태 수정 성공",   // 성공 메시지

--- a/src/main/java/com/carpBread/shareEatIt/domain/participation/controller/ParticipationController.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/participation/controller/ParticipationController.java
@@ -1,5 +1,7 @@
 package com.carpBread.shareEatIt.domain.participation.controller;
 
+import com.carpBread.shareEatIt.domain.auth.AuthUser;
+import com.carpBread.shareEatIt.domain.member.entity.Member;
 import com.carpBread.shareEatIt.domain.participation.dto.*;
 import com.carpBread.shareEatIt.domain.participation.entity.ParticipationStatus;
 import com.carpBread.shareEatIt.domain.participation.service.ParticipationService;
@@ -18,14 +20,12 @@ public class ParticipationController {
 
     private final ParticipationService participationService;
 
-    /* 로그인 구현 전 - 모든 기본 경로 뒤에 receiverId 붙여서 구현함 */
-
-    // 참여 생성 - 로그인 구현 전
-    @PostMapping("/{receiverId}")
+    // 참여 생성
+    @PostMapping()
     @ResponseStatus(HttpStatus.CREATED)
-    public ResponseEntity<ApiResponse<ParticipationResponseDto>> createParticipation(@PathVariable("receiverId") Long receiverId,
-                                                                                    @RequestBody @Valid final ParticipationRequestDto dto) {
-        ParticipationResponseDto responseDto = participationService.createParticipation(receiverId, dto);
+    public ResponseEntity<ApiResponse<ParticipationResponseDto>> createParticipation(@AuthUser Member receiver,
+                                                                                     @RequestBody @Valid final ParticipationRequestDto dto) {
+        ParticipationResponseDto responseDto = participationService.createParticipation(receiver, dto);
         ApiResponse<ParticipationResponseDto> response = new ApiResponse<>(
                 HttpStatus.CREATED.value(),  // 상태코드 201
                 "참여 생성 성공",   // 성공 메시지
@@ -36,10 +36,10 @@ public class ParticipationController {
 
 
     // 사용자의 나눔 참여 목록 전체 조회
-    @GetMapping("/{receiverId}")
+    @GetMapping()
     @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<ApiResponse<ParticipationHistoryListResponseDto>> getAllParticipation(@PathVariable("receiverId") Long receiverId){
-        ParticipationHistoryListResponseDto responseDto = participationService.findAllParticipation(receiverId);
+    public ResponseEntity<ApiResponse<ParticipationHistoryListResponseDto>> getAllParticipation(@AuthUser Member receiver){
+        ParticipationHistoryListResponseDto responseDto = participationService.findAllParticipation(receiver);
         ApiResponse<ParticipationHistoryListResponseDto> response = new ApiResponse<>(
                 HttpStatus.OK.value(),  // 상태코드 200
                 "사용자의 나눔 참여 목록 전체 조회 성공",   // 성공 메시지
@@ -50,11 +50,11 @@ public class ParticipationController {
 
 
     // 해당 제공 주체의 나눔 참여 목록 조회
-    @GetMapping("/{provider}/{receiverId}")
+    @GetMapping("/{provider}")
     @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<ApiResponse<ParticipationHistoryListResponseDto>> getParticipationByProvider(@PathVariable("receiverId") Long receiverId,
+    public ResponseEntity<ApiResponse<ParticipationHistoryListResponseDto>> getParticipationByProvider(@AuthUser Member receiver,
                                                                                                        @PathVariable("provider") PostType provider){
-        ParticipationHistoryListResponseDto responseDto = participationService.findAllParticipationByProvider(receiverId,provider);
+        ParticipationHistoryListResponseDto responseDto = participationService.findAllParticipationByProvider(receiver,provider);
         ApiResponse<ParticipationHistoryListResponseDto> response = new ApiResponse<>(
                 HttpStatus.OK.value(),  // 상태코드 200
                 "사용자의 나눔 참여 목록 중 특정 제공자의 나눔 참여 목록 조회 성공",   // 성공 메시지
@@ -65,12 +65,12 @@ public class ParticipationController {
 
 
     // 참여 테이블의 참여 상태 변경
-    @PatchMapping("/{ptId}/{receiverId}")
+    @PatchMapping("/{ptId}")
     @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<ApiResponse<ParticipationUpdateStatusResponseDto>> updateStatus(@PathVariable("ptId") Long ptId,
-                                                                                          @PathVariable("receiverId") Long receiverId,
+    public ResponseEntity<ApiResponse<ParticipationUpdateStatusResponseDto>> updateStatus(@AuthUser Member receiver,
+                                                                                          @PathVariable("ptId") Long ptId,
                                                                                           @RequestParam("status") ParticipationStatus status){
-        ParticipationUpdateStatusResponseDto responseDto = participationService.updateStatus(ptId,receiverId,status);
+        ParticipationUpdateStatusResponseDto responseDto = participationService.updateStatus(ptId,receiver,status);
         ApiResponse<ParticipationUpdateStatusResponseDto> response = new ApiResponse<>(
                 HttpStatus.OK.value(),  // 상태코드 200
                 "참여 상태 수정 성공",   // 성공 메시지

--- a/src/main/java/com/carpBread/shareEatIt/domain/participation/entity/Participation.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/participation/entity/Participation.java
@@ -41,13 +41,11 @@ public class Participation extends BaseEntity {
     @Nullable
     private LocalDateTime completedAt;
 
-//    @ManyToOne(cascade = CascadeType.ALL)
     @ManyToOne
     @JoinColumn(name = "giver_id")
     @NotNull
     private Member giver;
 
-//    @ManyToOne(cascade = CascadeType.ALL)
     @ManyToOne
     @JoinColumn(name = "receiver_id")
     @NotNull

--- a/src/main/java/com/carpBread/shareEatIt/domain/participation/entity/Participation.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/participation/entity/Participation.java
@@ -41,12 +41,14 @@ public class Participation extends BaseEntity {
     @Nullable
     private LocalDateTime completedAt;
 
-    @ManyToOne(cascade = CascadeType.ALL)
+//    @ManyToOne(cascade = CascadeType.ALL)
+    @ManyToOne
     @JoinColumn(name = "giver_id")
     @NotNull
     private Member giver;
 
-    @ManyToOne(cascade = CascadeType.ALL)
+//    @ManyToOne(cascade = CascadeType.ALL)
+    @ManyToOne
     @JoinColumn(name = "receiver_id")
     @NotNull
     private Member receiver;

--- a/src/main/java/com/carpBread/shareEatIt/domain/participation/service/GratitudeStickerService.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/participation/service/GratitudeStickerService.java
@@ -22,22 +22,22 @@ import java.util.List;
 @Transactional
 public class GratitudeStickerService {
 
-    private final MemberRepository memberRepository;
+//    private final MemberRepository memberRepository;
     private final SharingPostRepository sharingPostRepository;
     private final ParticipationRepository participationRepository;
     private final GratitudeStickerRepository gratitudeStickerRepository;
 
     /* 고마움 스티커 생성 */
-    public GratitudeResponseDto createGratitudeSticker(Long postId, Long memberId, GratitudeType gratitudeType){
+    public GratitudeResponseDto createGratitudeSticker(Long postId, Member member, GratitudeType gratitudeType){
 
         // 파라미터 값이 누락된 경우 예외 처리
-        if (postId == null || memberId == null) {
+        if (postId == null || member.getId() == null) {
             throw new IllegalArgumentException("postId or memberId cannot be null");
         }
-
-        // member 객체 찾기
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new RuntimeException("해당 Id의 member를 찾을 수 없습니다."));
+//
+//        // member 객체 찾기
+//        Member member = memberRepository.findById(memberId)
+//                .orElseThrow(() -> new RuntimeException("해당 Id의 member를 찾을 수 없습니다."));
 
         // SharingPost 객체 찾기
         SharingPost post = sharingPostRepository.findById(postId)
@@ -52,7 +52,7 @@ public class GratitudeStickerService {
         Participation participation = findSingleParticipation(postId);
 
         // 검증4 : 찾은 '참여' 데이터의 receiverId가 memberId와 같은지 확인
-        if (!memberId.equals(participation.getReceiver().getId())){
+        if (!member.getId().equals(participation.getReceiver().getId())){
             throw new IllegalStateException("해당 나눔을 받은 멤버가 아닙니다.");
         }
 
@@ -95,16 +95,12 @@ public class GratitudeStickerService {
 
 
     /* 고마움 스티커 수정 */
-    public GratitudeResponseDto updateGratitudeStickers(Long gratitudeStickerId, Long memberId, GratitudeType gratitudeType) {
+    public GratitudeResponseDto updateGratitudeStickers(Long gratitudeStickerId, Member member, GratitudeType gratitudeType) {
 
         // 파라미터 값이 누락된 경우 예외 처리
-        if (gratitudeStickerId == null || memberId == null) {
+        if (gratitudeStickerId == null || member == null) {
             throw new IllegalArgumentException("postId or memberId cannot be null");
         }
-
-        // member 객체 찾기
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new RuntimeException("해당 Id의 member를 찾을 수 없습니다."));
 
         // gratitudeSticker 객체 찾기
         GratitudeSticker gratitudeSticker = gratitudeStickerRepository.findById(gratitudeStickerId)
@@ -112,7 +108,7 @@ public class GratitudeStickerService {
 
         // 검증1 : 찾은 gratitudeSticker의 reviewerId가 memberId와 같은지 확인
         Member reviewer = gratitudeSticker.getReviewer();
-        if (reviewer == null || !memberId.equals(reviewer.getId())){
+        if (reviewer == null || !member.getId().equals(reviewer.getId())){
             throw new IllegalStateException("해당 나눔을 받은 멤버가 아닙니다.");
         }
 

--- a/src/main/java/com/carpBread/shareEatIt/domain/participation/service/GratitudeStickerService.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/participation/service/GratitudeStickerService.java
@@ -1,7 +1,6 @@
 package com.carpBread.shareEatIt.domain.participation.service;
 
 import com.carpBread.shareEatIt.domain.member.entity.Member;
-import com.carpBread.shareEatIt.domain.member.repository.MemberRepository;
 import com.carpBread.shareEatIt.domain.participation.dto.GratitudeResponseDto;
 import com.carpBread.shareEatIt.domain.participation.entity.GratitudeSticker;
 import com.carpBread.shareEatIt.domain.participation.entity.GratitudeType;
@@ -11,18 +10,20 @@ import com.carpBread.shareEatIt.domain.participation.repository.ParticipationRep
 import com.carpBread.shareEatIt.domain.sharingPost.entity.PostStatus;
 import com.carpBread.shareEatIt.domain.sharingPost.entity.SharingPost;
 import com.carpBread.shareEatIt.domain.sharingPost.repository.SharingPostRepository;
+import com.carpBread.shareEatIt.global.exception.AppException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.carpBread.shareEatIt.global.exception.ErrorCode.*;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class GratitudeStickerService {
 
-//    private final MemberRepository memberRepository;
     private final SharingPostRepository sharingPostRepository;
     private final ParticipationRepository participationRepository;
     private final GratitudeStickerRepository gratitudeStickerRepository;
@@ -31,21 +32,17 @@ public class GratitudeStickerService {
     public GratitudeResponseDto createGratitudeSticker(Long postId, Member member, GratitudeType gratitudeType){
 
         // 파라미터 값이 누락된 경우 예외 처리
-        if (postId == null || member.getId() == null) {
-            throw new IllegalArgumentException("postId or memberId cannot be null");
+        if (postId == null || member == null || gratitudeType == null) {
+            throw new AppException(CAN_NOT_BE_NULL, "필수 입력 값이 누락되었습니다.", "/gratitudeSticker");
         }
-//
-//        // member 객체 찾기
-//        Member member = memberRepository.findById(memberId)
-//                .orElseThrow(() -> new RuntimeException("해당 Id의 member를 찾을 수 없습니다."));
 
         // SharingPost 객체 찾기
         SharingPost post = sharingPostRepository.findById(postId)
-                .orElseThrow(() -> new RuntimeException("해당 Id의 post를 찾을 수 없습니다."));
+                .orElseThrow(() -> new AppException(NOT_FOUND_SHARINGPOST, "해당 Id의 SharingPost를 찾을 수 없습니다.", "/gratitudeStickers/" + postId));
 
         // 검증1 : 해당 나눔글의 상태가 COMPLETED인지 확인
         if (!post.getStatus().equals(PostStatus.COMPLETED)){
-            throw new IllegalStateException("완료되지 않은 나눔입니다.");
+            throw new AppException(NOT_COMPLETED_SHARINGPOST, "완료되지 않은 나눔입니다.", "/gratitudeStickers/" + postId);
         }
 
         // 해당 나눔글을 참조하고 있는 '참여' 데이터 중 상태가 COMPLETED인 참여 찾아오기
@@ -53,12 +50,12 @@ public class GratitudeStickerService {
 
         // 검증4 : 찾은 '참여' 데이터의 receiverId가 memberId와 같은지 확인
         if (!member.getId().equals(participation.getReceiver().getId())){
-            throw new IllegalStateException("해당 나눔을 받은 멤버가 아닙니다.");
+            throw new AppException(NOT_RECEIVER_OF_SHARINGPOST, "해당 나눔을 받은 멤버가 아닙니다.", "/gratitudeStickers/" + postId);
         }
 
         // 검증 5 : 이미 고마움을 남긴 경우
         if (gratitudeStickerRepository.existsByParticipationId(participation.getId())){
-            throw  new IllegalStateException("이미 고마움을 남긴 나눔입니다.");
+            throw new AppException(ALREADY_EXISTS_GRATITUDESTICKER, "이미 고마움을 남긴 나눔입니다.", "/gratitudeStickers/" + postId);
         }
 
         // GratitudeSticker 객체 생성
@@ -82,11 +79,11 @@ public class GratitudeStickerService {
         List<Participation> participationList = participationRepository.findByPostIdAndStatus(postId);
 
         if (participationList.isEmpty()) { // 검증2 : 찾지 못한 경우
-            throw new RuntimeException("해당 나눔글의 완료된 참여정보를 불러올 수 없습니다.");
+            throw new AppException(NOT_FOUND_PARTICIPATION, "해당 나눔글의 완료된 참여정보를 불러올 수 없습니다.", "/gratitudeStickers/" + postId);
         }
 
         if (participationList.size() > 1) { //검증3 : COMPLETED인 참여가 여러개인 경우
-            throw new IllegalStateException("같은 나눔글에 대해 참여 상태가 COMPLETED인 참여 객체가 여러개입니다.");
+            throw new AppException(MULTIPLE_COMPLETED_PARTICIPATIONS, "같은 나눔글에 대해 참여 상태가 COMPLETED인 참여 객체가 여러개입니다.", "/gratitudeStickers/" + postId);
         }
 
         // 리스트에 하나의 요소만 있을 때 그 객체를 반환
@@ -98,18 +95,18 @@ public class GratitudeStickerService {
     public GratitudeResponseDto updateGratitudeStickers(Long gratitudeStickerId, Member member, GratitudeType gratitudeType) {
 
         // 파라미터 값이 누락된 경우 예외 처리
-        if (gratitudeStickerId == null || member == null) {
-            throw new IllegalArgumentException("postId or memberId cannot be null");
+        if (gratitudeStickerId == null || member == null || gratitudeType == null) {
+            throw new AppException(CAN_NOT_BE_NULL, "필수 입력 값이 누락되었습니다.", "/gratitudeSticker");
         }
 
         // gratitudeSticker 객체 찾기
         GratitudeSticker gratitudeSticker = gratitudeStickerRepository.findById(gratitudeStickerId)
-                .orElseThrow(() -> new RuntimeException("해당 Id의 gratitudeSticker를 찾을 수 없습니다."));
+                .orElseThrow(() -> new AppException(NOT_FOUND_GRATITUDESTICKER, "해당 Id의 gratitudeSticker를 찾을 수 없습니다.", "/gratitudeSticker" + gratitudeStickerId));
 
         // 검증1 : 찾은 gratitudeSticker의 reviewerId가 memberId와 같은지 확인
         Member reviewer = gratitudeSticker.getReviewer();
         if (reviewer == null || !member.getId().equals(reviewer.getId())){
-            throw new IllegalStateException("해당 나눔을 받은 멤버가 아닙니다.");
+            throw new AppException(NOT_REVIEWER_OF_SHARINGPOST, "해당 나눔을 받은 멤버가 아닙니다.", "/gratitudeSticker" + gratitudeStickerId);
         }
 
         // 업데이트

--- a/src/main/java/com/carpBread/shareEatIt/domain/participation/service/ParticipationService.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/participation/service/ParticipationService.java
@@ -10,7 +10,6 @@ import com.carpBread.shareEatIt.domain.sharingPost.entity.PostType;
 import com.carpBread.shareEatIt.domain.sharingPost.entity.SharingPost;
 import com.carpBread.shareEatIt.domain.sharingPost.repository.SharingPostRepository;
 import com.carpBread.shareEatIt.global.exception.AppException;
-import com.carpBread.shareEatIt.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.carpBread.shareEatIt.global.exception.ErrorCode.*;
 
 @Service
 @Transactional
@@ -33,7 +34,7 @@ public class ParticipationService {
 
         // requestDto로 받아온 postId의 나눔글 조회
         SharingPost post = sharingPostRepository.findById(requestDto.getSharingPostId())
-                .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND_SHARINGPOST, "해당ID의 나눔글을 찾지 못했습니다.", "/participations"));
+                .orElseThrow(() -> new AppException(NOT_FOUND_SHARINGPOST, "해당ID의 나눔글을 찾지 못했습니다.", "/participations"));
 
 
         // Participation 객체 생성
@@ -94,7 +95,7 @@ public class ParticipationService {
 
         // participation 객체 찾아오기
         Participation participation = participationRepository.findById(ptId)
-                .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND_PARTICIPATION, "해당 ID의 참여기록을 찾지 못했습니다.", "/participation/"+ptId));
+                .orElseThrow(() -> new AppException(NOT_FOUND_PARTICIPATION, "해당 ID의 참여기록을 찾지 못했습니다.", "/participation/"+ptId));
 
         String sharingPostStatus = participation.getPost().getStatus().toString();
         String participationStatus = ptStatus.toString();
@@ -103,13 +104,13 @@ public class ParticipationService {
         if (sharingPostStatus.equals(participationStatus)){
             log.error("이미 나눔글이 {}인 상태로, 같은 상태로 변경 불가", sharingPostStatus);
             if (sharingPostStatus.equals("COMPLETED")){
-                throw new AppException(ErrorCode.ALREADY_COMPLETED_SHARINGPOST, "이미 나눔 완료된 나눔입니다.", "/participation/"+ptId);
+                throw new AppException(ALREADY_COMPLETED_SHARINGPOST, "이미 나눔 완료된 나눔입니다.", "/participation/"+ptId);
             }
             else if (sharingPostStatus.equals("MATCHED")){
-                throw new AppException(ErrorCode.ALREADY_MATCHED_SHARINGPOST, "이미 찜 상태인 나눔입니다.", "/participation/"+ptId);
+                throw new AppException(ALREADY_MATCHED_SHARINGPOST, "이미 찜 상태인 나눔입니다.", "/participation/"+ptId);
             }
             else {
-                throw new AppException(ErrorCode.ALREADY_AVAILABLE_SHARINGPSOT, "현재 나눔 가능한 상태로 변경할 상태가 없습니다.", "/participation/"+ptId);
+                throw new AppException(ALREADY_AVAILABLE_SHARINGPSOT, "현재 나눔 가능한 상태로 변경할 상태가 없습니다.", "/participation/"+ptId);
             }
         }
 
@@ -118,7 +119,7 @@ public class ParticipationService {
             log.error("사용자 != 나눔글 작성자");
             log.info("giverId : {}", giver.getId());
             log.info("writerId : {}", participation.getPost().getWriter().getId());
-            throw new AppException(ErrorCode.NOT_WRITER_OF_SHARINGPOST, "나눔글 작성자가 아니므로 나눔 상태를 변경할 수 없습니다.", "/participation/"+ptId);
+            throw new AppException(NOT_WRITER_OF_SHARINGPOST, "나눔글 작성자가 아니므로 나눔 상태를 변경할 수 없습니다.", "/participation/"+ptId);
         }
 
         // 상태 변경
@@ -132,7 +133,7 @@ public class ParticipationService {
             post.updateStatus(postStatus);
         } catch (IllegalArgumentException e) {
             log.error("잘못된 상태값으로, 해당 나눔글의 상태 변경에 실패");
-            throw new AppException(ErrorCode.INVALID_STATUS_VALUE ,"잘못된 상태값으로, 해당 나눔글의 상태 변경에 실패하였습니다.", "/participation/"+ptId);
+            throw new AppException(INVALID_STATUS_VALUE ,"잘못된 상태값으로, 해당 나눔글의 상태 변경에 실패하였습니다.", "/participation/"+ptId);
         }
 
         // 변경한 내용 저장

--- a/src/main/java/com/carpBread/shareEatIt/domain/participation/service/ParticipationService.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/participation/service/ParticipationService.java
@@ -24,14 +24,9 @@ public class ParticipationService {
 
     private final ParticipationRepository participationRepository;
     private final SharingPostRepository sharingPostRepository;
-    private final MemberRepository memberRepository;
 
     /* 참여 생성 - 나눔글 채팅 참여 */
-    public ParticipationResponseDto createParticipation(Long receiverId, ParticipationRequestDto requestDto) {
-
-        // member 조회 - 로그인 구현 이후 수정 필요
-        Member receiver = memberRepository.findById(receiverId)
-                .orElseThrow(() -> new RuntimeException("해당ID의 회원을 찾지 못했습니다."));
+    public ParticipationResponseDto createParticipation(Member receiver, ParticipationRequestDto requestDto) {
 
         // requestDto로 받아온 postId의 나눔글 조회
         SharingPost post = sharingPostRepository.findById(requestDto.getSharingPostId())
@@ -58,14 +53,10 @@ public class ParticipationService {
 
 
     /* 사용자가 나눔받은 모든 기록 조회 */
-    public ParticipationHistoryListResponseDto findAllParticipation(Long receiverId) {
-
-        // member 조회 - 로그인 구현 이후 수정 필요
-        Member receiver = memberRepository.findById(receiverId)
-                .orElseThrow(() -> new RuntimeException("해당ID의 회원을 찾지 못했습니다."));
+    public ParticipationHistoryListResponseDto findAllParticipation(Member receiver) {
 
         // 사용자 = receiver이고 나눔완료 상태인 모든 '참여'의 나눔글 조회
-        List<SharingPost> participatedPosts = participationRepository.findSharingPostByUserAndStatus(receiverId);
+        List<SharingPost> participatedPosts = participationRepository.findSharingPostByUserAndStatus(receiver.getId());
 
         // 조회된 각 나눔글을 응답dto 리스트로 변환
         List<ParticipationHistoryResponseDto> dtoList = convertDtoToList(participatedPosts);
@@ -75,14 +66,10 @@ public class ParticipationService {
 
 
     /* 사용자가 특정 provider의 나눔을 받은 모든 기록 조회 */
-    public ParticipationHistoryListResponseDto findAllParticipationByProvider(Long receiverId, PostType provider) {
-
-        // member 조회 - 로그인 구현 이후 수정 필요
-        Member receiver = memberRepository.findById(receiverId)
-                .orElseThrow(() -> new RuntimeException("해당ID의 회원을 찾지 못했습니다."));
+    public ParticipationHistoryListResponseDto findAllParticipationByProvider(Member receiver, PostType provider) {
 
         // 사용자 = receiver이고 상태 = 나눔완료인 모든 '참여'의 나눔글 중 특정 provider의 글 조회
-        List<SharingPost> participatedPosts = participationRepository.findSharingPostByUserAndStatusAndPostType(receiverId, provider);
+        List<SharingPost> participatedPosts = participationRepository.findSharingPostByUserAndStatusAndPostType(receiver.getId(), provider);
 
         // 조회된 각 나눔글을 응답dto 리스트로 변환
         List<ParticipationHistoryResponseDto> dtoList = convertDtoToList(participatedPosts);
@@ -99,11 +86,7 @@ public class ParticipationService {
 
 
     /* 참여 상태 변경 */
-    public ParticipationUpdateStatusResponseDto updateStatus(Long ptId, Long receiverId, ParticipationStatus ptStatus) {
-
-        // member 조회 - 로그인 구현 이후 수정 필요
-        Member receiver = memberRepository.findById(receiverId)
-                .orElseThrow(() -> new RuntimeException("해당ID의 회원을 찾지 못했습니다."));
+    public ParticipationUpdateStatusResponseDto updateStatus(Long ptId, Member receiver, ParticipationStatus ptStatus) {
 
         // participation 객체 찾아오기
         Participation participation = participationRepository.findById(ptId)
@@ -118,7 +101,7 @@ public class ParticipationService {
         }
 
         // 검증2: 사용자가 나눔자의 writer인지 확인
-        if (receiverId != participation.getPost().getWriter().getId()){
+        if (receiver.getId() != participation.getPost().getWriter().getId()){
             throw new RuntimeException("나눔글 작성자가 아니므로 나눔 상태를 변경할 수 없습니다.");
         }
 

--- a/src/main/java/com/carpBread/shareEatIt/domain/participation/service/ParticipationService.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/participation/service/ParticipationService.java
@@ -90,7 +90,7 @@ public class ParticipationService {
 
 
     /* 참여 상태 변경 */
-    public ParticipationUpdateStatusResponseDto updateStatus(Long ptId, Member receiver, ParticipationStatus ptStatus) {
+    public ParticipationUpdateStatusResponseDto updateStatus(Long ptId, Member giver, ParticipationStatus ptStatus) {
 
         // participation 객체 찾아오기
         Participation participation = participationRepository.findById(ptId)
@@ -114,8 +114,10 @@ public class ParticipationService {
         }
 
         // 검증2: 사용자가 나눔자의 writer인지 확인
-        if (!receiver.getId().equals(participation.getPost().getWriter().getId())){
+        if (!giver.getId().equals(participation.getPost().getWriter().getId())){
             log.error("사용자 != 나눔글 작성자");
+            log.info("giverId : {}", giver.getId());
+            log.info("writerId : {}", participation.getPost().getWriter().getId());
             throw new AppException(ErrorCode.NOT_WRITER_OF_SHARINGPOST, "나눔글 작성자가 아니므로 나눔 상태를 변경할 수 없습니다.", "/participation/"+ptId);
         }
 

--- a/src/main/java/com/carpBread/shareEatIt/global/exception/ErrorCode.java
+++ b/src/main/java/com/carpBread/shareEatIt/global/exception/ErrorCode.java
@@ -8,7 +8,16 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND),
-    INVALID_ACCESS_TOKEN(HttpStatus.NOT_ACCEPTABLE);
+    INVALID_ACCESS_TOKEN(HttpStatus.NOT_ACCEPTABLE),
+
+    // Participation
+    NOT_FOUND_SHARINGPOST(HttpStatus.NOT_FOUND),
+    NOT_FOUND_PARTICIPATION(HttpStatus.NOT_FOUND),
+    ALREADY_COMPLETED_SHARINGPOST(HttpStatus.BAD_REQUEST),   // 이미 나눔완료된 나눔인 경우
+    ALREADY_MATCHED_SHARINGPOST(HttpStatus.BAD_REQUEST),     // 이니 찜된 나눔인 경우
+    ALREADY_AVAILABLE_SHARINGPSOT(HttpStatus.BAD_REQUEST),   // 이미 나눔가능한 상태의 나눔인 경우
+    NOT_WRITER_OF_SHARINGPOST(HttpStatus.FORBIDDEN),         // 사용자가 나눔긓의 writer인지 확인
+    INVALID_STATUS_VALUE(HttpStatus.BAD_REQUEST);
 
     private final HttpStatus status;
 }

--- a/src/main/java/com/carpBread/shareEatIt/global/exception/ErrorCode.java
+++ b/src/main/java/com/carpBread/shareEatIt/global/exception/ErrorCode.java
@@ -11,13 +11,24 @@ public enum ErrorCode {
     INVALID_ACCESS_TOKEN(HttpStatus.NOT_ACCEPTABLE),
 
     // Participation
-    NOT_FOUND_SHARINGPOST(HttpStatus.NOT_FOUND),
     NOT_FOUND_PARTICIPATION(HttpStatus.NOT_FOUND),
     ALREADY_COMPLETED_SHARINGPOST(HttpStatus.BAD_REQUEST),   // 이미 나눔완료된 나눔인 경우
     ALREADY_MATCHED_SHARINGPOST(HttpStatus.BAD_REQUEST),     // 이니 찜된 나눔인 경우
     ALREADY_AVAILABLE_SHARINGPSOT(HttpStatus.BAD_REQUEST),   // 이미 나눔가능한 상태의 나눔인 경우
-    NOT_WRITER_OF_SHARINGPOST(HttpStatus.FORBIDDEN),         // 사용자가 나눔긓의 writer인지 확인
-    INVALID_STATUS_VALUE(HttpStatus.BAD_REQUEST);
+    NOT_WRITER_OF_SHARINGPOST(HttpStatus.FORBIDDEN),         // 사용자가 나눔글의 writer인지 확인
+    INVALID_STATUS_VALUE(HttpStatus.BAD_REQUEST),
+    NOT_RECEIVER_OF_SHARINGPOST(HttpStatus.FORBIDDEN),        // 사용자가 나눔을 받은 참여자인지 확인
+    MULTIPLE_COMPLETED_PARTICIPATIONS(HttpStatus.FORBIDDEN),  // 같은 나눔글에 대해 참여 상태가 COMPLETED인 참여 객체가 여러개인 경우
+
+    // GratitudeSticker
+    CAN_NOT_BE_NULL(HttpStatus.NO_CONTENT),                   // 값이 누락된 경우 예외 처리
+    ALREADY_EXISTS_GRATITUDESTICKER(HttpStatus.FORBIDDEN),    // 이미 고마움을 남긴 경우
+    NOT_FOUND_GRATITUDESTICKER(HttpStatus.NOT_FOUND),
+    NOT_REVIEWER_OF_SHARINGPOST(HttpStatus.FORBIDDEN),
+
+    // SharingPost
+    NOT_FOUND_SHARINGPOST(HttpStatus.NOT_FOUND),
+    NOT_COMPLETED_SHARINGPOST(HttpStatus.FORBIDDEN);
 
     private final HttpStatus status;
 }


### PR DESCRIPTION
## 변경 사항
 - #9 , #11 
    - 로그인 인증 적용
    - 커스텀 에러 처리로 변경    

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 , 폴더명 , 파일 경로 수정
- [ ] 파일 혹은 폴더 삭제


### 반영 브랜치
ex) feat/participation-> develop

### 테스트 결과
- 참여 생성 기능 
<img src="https://github.com/user-attachments/assets/f2006ae4-68b7-4a95-9911-760974bd0d76" alt="참여 생성 기능" width="500"/>

- 사용자의 나눔 참여 목록 조회 (이미지 응답 제외)
<img src="https://github.com/user-attachments/assets/485619d6-1add-477d-b560-ecaa27dd0ce2" alt="사용자의 나눔 참여 목록 조회" width="500"/>

- 사용자가 특정 제공 주체의 나눔에 참여한 목록 조회
<img src="https://github.com/user-attachments/assets/cd625242-b490-4bcd-adbf-f50bf95e077e" alt="특정 제공 주체의 나눔 참여 목록 조회" width="500"/>

- 참여 상태 변경 
<img src="https://github.com/user-attachments/assets/52e474ca-73b7-4285-8ab9-9b6738e7418e" alt="참여 상태 변경" width="500"/>

- 고마움 남기기(생성)
<img src="https://github.com/user-attachments/assets/d2dabf7c-0c69-4d54-990c-86332288a48a" alt="고마움 남기기" width="500"/>

- 남긴 고마움 수정
<img src="https://github.com/user-attachments/assets/2160cef8-2b2e-4f23-969d-826baeb14ee3" alt="남긴 고마움 수정" width="500"/>


### ETC
- 생각보다 로그인 방식을 도입하는 과정에서 예상치 못한 에러들과 실수들을 만남