### PR TITLE
fix: 웹소켓 연결시(CONNECT) 토큰 인증 구현

### DIFF
--- a/src/main/java/com/carpBread/shareEatIt/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/chat/controller/ChatController.java
@@ -26,7 +26,7 @@ public class ChatController {
     private final ChatMessageService chatMessageService;
     private final SimpMessageSendingOperations messagingTemplate;
 
-    /* 채팅 */
+    /* 채팅 - 메시지 전달*/
     @MessageMapping("/chat/message/{chatRoomId}")  // app/chat/message/{chatRoomId} 로 메세지 발송
     public ChatMessageResponseDto sendMessage(@Payload ChatMessageRequestDto requestDto) {
         ChatMessageResponseDto responseDto = chatMessageService.saveMessage(requestDto);

--- a/src/main/java/com/carpBread/shareEatIt/domain/chat/stompWebSocket/FilterChannelInterceptor.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/chat/stompWebSocket/FilterChannelInterceptor.java
@@ -1,0 +1,141 @@
+package com.carpBread.shareEatIt.domain.chat.stompWebSocket;
+
+import com.carpBread.shareEatIt.domain.auth.OAuth2Principal;
+import com.carpBread.shareEatIt.domain.auth.util.JWTUtils;
+import com.carpBread.shareEatIt.domain.member.entity.Member;
+import com.carpBread.shareEatIt.domain.member.repository.MemberRepository;
+import com.carpBread.shareEatIt.global.exception.AppException;
+import io.jsonwebtoken.JwtException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+import static com.carpBread.shareEatIt.global.exception.ErrorCode.UNAUTHORIZED_JWT;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Order(Ordered.HIGHEST_PRECEDENCE + 99)
+public class FilterChannelInterceptor implements ChannelInterceptor {
+
+    private final JWTUtils jwtUtils;
+    private final MemberRepository memberRepository;
+    private final RedisTemplate redisTemplate;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+
+        // STOMP 헤더에 직접 접근
+        StompHeaderAccessor headerAccessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        log.info("로그 >>>>>> headerAccessor : {}", headerAccessor);  // header 내용 확인
+
+        assert headerAccessor != null;
+        log.info("로그 >>>>>> headAccessorHeaders : {}", headerAccessor.getCommand());  // CONNECT, SEND 인지 확인
+
+        // StompCommand 를 통해 연결(CONNECT)시점에 토큰을 확인하는 과정
+        if (Objects.equals(headerAccessor.getCommand(), StompCommand.CONNECT)) { // 문제 발생 예상 지점
+            String authorization = removeBrackets(String.valueOf(headerAccessor.getNativeHeader("Authorization")));
+            log.info("로그 >>>>>> authorization(AccessToken): {}", authorization);
+
+            // 토큰 검증
+            try {
+                checkToken(authorization);
+
+            } catch (Exception e) {
+                log.error("토큰 인증 실패 (Authentication failed): {}", e.getMessage());
+                // 에러 응답을 보내고 연결을 종료
+                headerAccessor.setLeaveMutable(true);  // 헤더를 수정 가능하게 설정
+                headerAccessor.setMessage("토큰 인증 실패" + e.getMessage());
+                // 예외 발생 시, 연결 종료
+                return new GenericMessage<>("토큰 인증 실패" + e.getMessage());
+            }
+        }
+        return message;
+    }
+
+
+    // 헤더에서 토큰 추출
+    private String removeBrackets(String token) {
+        if (token.startsWith("[") && token.endsWith("]")) {
+            return token.substring(1, token.length() - 1);
+        }
+        return token;
+    }
+
+
+    // 토큰 인증 - 일반적인 HTTP 메소드가 아니므로 JWTFilter의 인증 과정 사용 불가하여 따로 작성한 것
+    private void checkToken(String authorization) {
+
+        try {
+            // 1. 토큰 유무 확인
+            if (authorization == null || !authorization.startsWith("Bearer")) {
+                log.error("토큰이 존재하지 않습니다");
+                throw new JwtException("토큰이 존재하지 않습니다.");
+            }
+
+            String token = authorization.split("\\+")[1];
+
+            // 2. 토큰 기한 만료 여부 확인
+            if (jwtUtils.isExpired(token)) {
+                log.error("토큰 기한이 만료되었습니다.");
+                throw new JwtException("토큰 기한이 만료되었습니다.");
+
+            }
+
+            // 3. context authentication에 저장하기
+            String email = jwtUtils.getEmail(token);
+            Member member = memberRepository.findByEmail(email)
+                    .orElse(null);
+
+            // 3-1 * : 로그아웃된 JWT인지 확인
+            Set<String> keys = redisTemplate.keys("token:" + email + ":*");
+
+            if (keys != null) {
+                for (String key : keys) {
+                    String logoutToken = (String) redisTemplate.opsForValue().get(key);
+                    if (token.equals(logoutToken)) {
+                        log.error("로그아웃된 토큰입니다. 다시 로그인해주세요.");
+                        throw new JwtException("로그아웃된 토큰입니다. 다시 로그인해주세요.");
+                    }
+                }
+            }
+
+            if (member == null || !email.equals(member.getEmail())) {
+                log.error("회원가입되어있지 않습니다.");
+                throw new JwtException("회원가입 되어있지 않습니다.");
+            }
+
+            OAuth2Principal principal = new OAuth2Principal(member);
+            SimpleGrantedAuthority grantedAuthority = new SimpleGrantedAuthority("ROLE_MEMBER");
+            UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(principal, "kakao", Collections.singleton(grantedAuthority));
+            SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+
+        } catch (JwtException e) {
+            System.out.println("================= jwt 필터에서 오류가 납니다. jwtException 중 하나 " + e.getMessage());
+            throw new JwtException("JwtException - jwt 인증 오류");  // preSend에서 catch문에 걸리기 위함
+        } catch (Exception e) {
+            System.out.println("================= jwt 필터에서 오류가 납니다. 그냥 exception 중 하나 " + e.getMessage());
+            throw new AppException(UNAUTHORIZED_JWT, "Exception - jwt 인증 오류", "/ws" );  // preSend에서 catch문에 걸리기 위함
+
+        }
+
+    }
+
+}

--- a/src/main/java/com/carpBread/shareEatIt/global/config/WebSocketConfig.java
+++ b/src/main/java/com/carpBread/shareEatIt/global/config/WebSocketConfig.java
@@ -1,7 +1,10 @@
 package com.carpBread.shareEatIt.global.config;
 
+import com.carpBread.shareEatIt.domain.chat.stompWebSocket.FilterChannelInterceptor;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -10,8 +13,10 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @Configuration
 @EnableWebSocketMessageBroker  // WebSocket 메시지 처리를 가능하게 해주는 메시지 브로커를 활성화
 @RequiredArgsConstructor
+@Slf4j
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+    private final FilterChannelInterceptor filterChannelInterceptor;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry){
@@ -30,5 +35,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         config.setApplicationDestinationPrefixes("/app");  // @MessageMapping이 붙은 메서드에 바인딩되는 메시지의 경로를 지정
     }
 
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        log.info("소켓 통신 연결 전(CONNECT) 토큰 인증 과정");
+        registration.interceptors(filterChannelInterceptor);
+    }
 
 }


### PR DESCRIPTION
## 변경 사항
 - #47 
 - 웹소켓 연결시 헤더의 토큰 인증 과정 추가

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 , 폴더명 , 파일 경로 수정
- [ ] 파일 혹은 폴더 삭제


### 반영 브랜치
ex) feat/chatting-> develop

### 테스트 결과
- 올바른 토큰을 넣어 연결 요청한 경우
![image](https://github.com/user-attachments/assets/959e70a0-ded8-421b-831b-7b36cafc1639)
![image](https://github.com/user-attachments/assets/a83a1f06-7843-42d0-aab3-e03b1a634b9e)

- 만료된 토큰을 넣어 요청한 경우 
![image](https://github.com/user-attachments/assets/444f8e2c-6048-4c84-b41e-707ec4e38740)
<img width="1040" alt="image" src="https://github.com/user-attachments/assets/d56d285a-1fa2-4922-a3f3-e849039304ff">

- 잘못된 토큰을 넣어 요청한 경우
![image](https://github.com/user-attachments/assets/62497e1d-b062-46fb-9eab-4ff02885b169)
![image](https://github.com/user-attachments/assets/3e3e43fd-74bd-4aed-a230-f057271f3516)

- 토큰이 없는 경우 
![image](https://github.com/user-attachments/assets/4126eab7-ae59-49de-927b-dd8d08348d1d)
![image](https://github.com/user-attachments/assets/39b47cb4-b408-4faf-a16c-52146d2d9e4a)

### ETC
- 올바른 토큰인 경우에만 소켓이 열려있도록 설정함
- 올바르지 않은 토큰일 경우 연결되지 않으며, 로그로 상세 이유를 알 수 있도록 설정함
- 웹 소켓의 경우 헤더의 토큰을 검사하던 프로토콜이 HTTP와 달라 HTTP 연결할 때 처럼 일반적으로 헤더에 토큰을 넣어주면 토큰 없음 에러 발생함
- 따라서 ChannelInterceptor를 구현하는 FilterChannelInterceptor 구현클래스를 생성해 별도로 인증 과정을 작성하고,
이 인터셉트를 WebSocketConfig 파일에 등록하여 구현함 
(기존의 JwtFilter는 거치지 않도록 함)