### PR TITLE
fix: 웹소켓 연결시(CONNECT) 토큰 넣어주는 형식 수정

### DIFF
--- a/src/main/java/com/carpBread/shareEatIt/domain/chat/stompWebSocket/FilterChannelInterceptor.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/chat/stompWebSocket/FilterChannelInterceptor.java
@@ -90,7 +90,7 @@ public class FilterChannelInterceptor implements ChannelInterceptor {
                 throw new JwtException("토큰이 존재하지 않습니다.");
             }
 
-            String token = authorization.split("\\+")[1];
+            String token = authorization.split(" ")[1];
 
             // 2. 토큰 기한 만료 여부 확인
             if (jwtUtils.isExpired(token)) {


### PR DESCRIPTION
## 변경 사항
 - #47 
 - jwt 토큰 형식의 변화에 따라 웹소켓 인증에서도 마찬가지로 변경 
 - 기존: Bearer+eyJhbGciOiJIUzI1NiJ9.eyJu  
 - 수정 후: Bearer eyJhbGciOiJIUzI1NiJ9.eyJu

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 , 폴더명 , 파일 경로 수정
- [ ] 파일 혹은 폴더 삭제


### 반영 브랜치
ex) feat/chatting-> develop

### 테스트 결과
<img width="1100" alt="image" src="https://github.com/user-attachments/assets/0b6b507f-cd3d-4607-93ef-e84d3716e053">

### ETC
- 