### PR TITLE
fix: 웹소켓 연결시(CONNECT) 기존 JWTFilter에 걸리지 않도록 수정

### DIFF
--- a/src/main/java/com/carpBread/shareEatIt/domain/auth/util/JWTFilter.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/auth/util/JWTFilter.java
@@ -114,7 +114,7 @@ public class JWTFilter extends OncePerRequestFilter {
 
     private boolean isOmissionUrl(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException{
         // 토큰 검증을 생략할 경로
-        if (request.getRequestURI().startsWith("/login") || request.getRequestURI().startsWith("/favicon.ico") ) {
+        if (request.getRequestURI().startsWith("/login") || request.getRequestURI().startsWith("/favicon.ico") || request.getRequestURI().startsWith("/ws")) {
             return true;
         }
 

--- a/src/main/java/com/carpBread/shareEatIt/domain/chat/stompWebSocket/FilterChannelInterceptor.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/chat/stompWebSocket/FilterChannelInterceptor.java
@@ -85,7 +85,7 @@ public class FilterChannelInterceptor implements ChannelInterceptor {
 
         try {
             // 1. 토큰 유무 확인
-            if (authorization == null || !authorization.startsWith("Bearer")) {
+            if (authorization == null || !authorization.startsWith("Bearer ")) {
                 log.error("토큰이 존재하지 않습니다");
                 throw new JwtException("토큰이 존재하지 않습니다.");
             }


### PR DESCRIPTION
## 변경 사항
 - #47 
 - 웹소켓 연결시(CONNECT) 기존 JWTFilter에 걸리지 않도록 한 기존의 코드가 삭제되어 다시 추가함

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 , 폴더명 , 파일 경로 수정
- [ ] 파일 혹은 폴더 삭제


### 반영 브랜치
ex) feat/chatting-> develop

### 테스트 결과
![image](https://github.com/user-attachments/assets/72c6c380-91ce-4537-b863-75c48a821985)

### ETC
- 