### PR TITLE
fix : GET 요청에 REQUEST BODY -> REQUEST PARAM 변경

### DIFF
--- a/src/main/java/com/carpBread/shareEatIt/domain/sharingPost/controller/MapController.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/sharingPost/controller/MapController.java
@@ -8,15 +8,13 @@ import com.carpBread.shareEatIt.domain.sharingPost.dto.map.MapRequestDto;
 import com.carpBread.shareEatIt.domain.sharingPost.service.SharingPostService;
 import com.carpBread.shareEatIt.global.response.ApiResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,7 +25,14 @@ public class MapController {
 
     @GetMapping("/list")
     public ResponseEntity<ApiResponse<MapListResponseDto>> getMapList(@AuthUser Member member,
-                                                                      @Valid @RequestBody MapRequestDto dto){
+                                                                      @NotBlank @RequestParam(name = "longitude")Double longitude,
+                                                                      @NotBlank @RequestParam(name = "latitude")Double latitude){
+        MapRequestDto dto = MapRequestDto.builder()
+                .longitude(longitude)
+                .latitude(latitude)
+                .build();
+
+
         MapListResponseDto responseDto = sharingPostService.getMapList(member,dto);
 
         ApiResponse<MapListResponseDto> response = new ApiResponse<>(HttpStatus.OK.value(),"지도 나눔글 목록 조회 성공", responseDto);

--- a/src/main/java/com/carpBread/shareEatIt/domain/sharingPost/controller/SharingPostController.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/sharingPost/controller/SharingPostController.java
@@ -6,6 +6,7 @@ import com.carpBread.shareEatIt.domain.sharingPost.dto.*;
 import com.carpBread.shareEatIt.domain.sharingPost.service.SharingPostService;
 import com.carpBread.shareEatIt.global.response.ApiResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,6 +16,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
+/* 나눔글 CRUD controller */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/sharing")
@@ -34,9 +36,17 @@ public class SharingPostController {
         return ResponseEntity.ok().body(response);
     }
 
-    @GetMapping
+    @GetMapping("/list")
     public ResponseEntity<ApiResponse<SharingPostListResponseDto>> findSharingPostListByProviderType(@AuthUser Member member,
-                                                                  @Valid @RequestBody SharingPostListRequestDto dto){
+                                                                                                     @NotBlank @RequestParam(name = "postType")String postType,
+                                                                                                     @NotBlank @RequestParam(name = "latitude")Double latitude,
+                                                                                                     @NotBlank @RequestParam(name = "longitude")Double longitude){
+        SharingPostListRequestDto dto = SharingPostListRequestDto.builder()
+                .postType(postType)
+                .latitude(latitude)
+                .longitude(longitude)
+                .build();
+
         SharingPostListResponseDto responseDto = sharingPostService.findPostListByProviderType(member, dto);
 
         ApiResponse<SharingPostListResponseDto> response = new ApiResponse<>(HttpStatus.OK.value(),"나눔글 리스트 조회 성공", responseDto);

--- a/src/main/java/com/carpBread/shareEatIt/domain/sharingPost/dto/SharingPostListRequestDto.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/sharingPost/dto/SharingPostListRequestDto.java
@@ -1,11 +1,14 @@
 package com.carpBread.shareEatIt.domain.sharingPost.dto;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-@Getter
+@AllArgsConstructor
+@Getter @Builder
 public class SharingPostListRequestDto {
     @NotNull
     private String postType;

--- a/src/main/java/com/carpBread/shareEatIt/domain/sharingPost/dto/map/MapRequestDto.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/sharingPost/dto/map/MapRequestDto.java
@@ -1,11 +1,14 @@
 package com.carpBread.shareEatIt.domain.sharingPost.dto.map;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-@Getter
+@AllArgsConstructor
+@Getter @Builder
 public class MapRequestDto {
 
     @NotNull


### PR DESCRIPTION
## HTTP 표준 규약에서는 GET 요청에서 REQUEST BODY를 사용하는 것을 지양하고 있다.
대부분의 서버, 클라이언트, 프록시에서 GET 요청의 REQUEST BODY는 처음부터 무시될 수도 있다고 한다.