### PR TITLE
fix : class level에서는 validation 어노테이션 사용 불가 오류 수정

### DIFF
--- a/src/main/java/com/carpBread/shareEatIt/domain/member/dto/MemberProfileUpdateRequestDto.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/member/dto/MemberProfileUpdateRequestDto.java
@@ -9,16 +9,23 @@ import lombok.NoArgsConstructor;
 @Getter @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@NotBlank
 public class MemberProfileUpdateRequestDto {
     private String profileImg;
+
+    @NotBlank
     private String nickname;
+
+    @NotBlank
     private String provider;
 
+    @NotBlank
     private Double latitude;
+    @NotBlank
     private Double longitude;
 
+    @NotBlank
     private String addressSt;
+    @NotBlank
     private String addressDetail;
 
 


### PR DESCRIPTION
## class 레벨에서는 notblank validation 어노테이션 사용 불가
### 왜?
유효성 검사의 대상이 다르기 때문이다.

@NotBlank, @Size 등과 같은 validation 어노테이션들은 특정 필드에 대해 값의 유효성을 검사하도록 설계되었다. 예를 들어, @NotBlank는 String 타입 필드에서만 작동한다.
클레스 레벨에서는  필드 하나가 아니라 객체 전체의 유효성을 검사해야 하므로, custom constraint를 정의하는 것이 바람직하다.

### @Getter는 되고 @NotBlank는 안된다?
@Getter와 같은 Lombok 어노테이션은 동작 방식이 다르다. 컴파일 시점에 코드 생성을 통해 작동된다. 클래스 전체에 붙으면 ``컴파일러`` 수준에서, 모든 필드에 대해 getter 메소드를 컴파일된 바이트코드에 포함시킨다.
** Lombok은 자바의 표준 라이브러리나 검증 매커니즘과는 별개로 동작하기 때문에 클래스를 통째로 다루는 유효성 검증과는 목적이 다르다.

validation 어노테이션은 ``런타임``에 실행되는 Java Bean Validation의 표준 규격에 따라 동작한다. 