### PR TITLE
fix: 참여 생성시 응답값에 생성된 채팅방Id 포함하도록 수정

### DIFF
--- a/src/main/java/com/carpBread/shareEatIt/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/chat/controller/ChatRoomController.java
@@ -3,6 +3,7 @@ package com.carpBread.shareEatIt.domain.chat.controller;
 import com.carpBread.shareEatIt.domain.auth.AuthUser;
 import com.carpBread.shareEatIt.domain.chat.dto.ChatRoomListResponseDto;
 import com.carpBread.shareEatIt.domain.chat.dto.ChatRoomResponseDto;
+import com.carpBread.shareEatIt.domain.chat.entity.ChatRoom;
 import com.carpBread.shareEatIt.domain.chat.service.ChatRoomService;
 import com.carpBread.shareEatIt.domain.member.entity.Member;
 import com.carpBread.shareEatIt.global.response.ApiResponse;
@@ -23,7 +24,8 @@ public class ChatRoomController {
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<ApiResponse<ChatRoomResponseDto>> createChatRoom(@AuthUser Member member,
                                                                            @RequestParam(name = "ptId")Long participationId){
-        ChatRoomResponseDto responseDto = chatRoomService.createChatRoom(member, participationId);
+        ChatRoom savedChatRoom = chatRoomService.createChatRoom(member, participationId);
+        ChatRoomResponseDto responseDto = chatRoomService.changeChatRoomToDto(savedChatRoom);
         ApiResponse<ChatRoomResponseDto> response = new ApiResponse<>(
                 HttpStatus.CREATED.value(),
                 "채팅방 생성",

--- a/src/main/java/com/carpBread/shareEatIt/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/chat/service/ChatRoomService.java
@@ -28,7 +28,7 @@ public class ChatRoomService {
     private final ChatRoomRepository chatRoomRepository;
 
     /* 채팅방 생성 */
-    public ChatRoomResponseDto createChatRoom(Member member, Long participationId) {
+    public ChatRoom createChatRoom(Member member, Long participationId) {
 
         // Participation 객체 찾기
         Participation participation = participationRepository.findById(participationId)
@@ -40,12 +40,15 @@ public class ChatRoomService {
                 .status(ChatRoomStatus.ACTIVE)
                 .build();
 
-        // 저장
-        ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
+        // 저장 & 반환
+        return chatRoomRepository.save(chatRoom);
 
+    }
 
+    // 채팅방 생성 dto로 반환
+    public ChatRoomResponseDto changeChatRoomToDto(ChatRoom chatRoom){
         // 응답 dto로 반환
-        return ChatRoomResponseDto.from(savedChatRoom);
+        return ChatRoomResponseDto.from(chatRoom);
     }
 
 

--- a/src/main/java/com/carpBread/shareEatIt/domain/participation/dto/ParticipationResponseDto.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/participation/dto/ParticipationResponseDto.java
@@ -1,5 +1,6 @@
 package com.carpBread.shareEatIt.domain.participation.dto;
 
+import com.carpBread.shareEatIt.domain.chat.entity.ChatRoom;
 import com.carpBread.shareEatIt.domain.participation.entity.ParticipationStatus;
 import com.carpBread.shareEatIt.domain.participation.entity.Participation;
 import lombok.AccessLevel;
@@ -16,27 +17,32 @@ public class ParticipationResponseDto {
     private Long sharingPostId;
     private Long giverId;
     private Long receiverId;
+    private Long chatRoomId;
     private ParticipationStatus status;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
     @Builder
-    public ParticipationResponseDto(Long participationId, Long sharingPostId, Long giverId, Long receiverId, ParticipationStatus status, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+    public ParticipationResponseDto(Long participationId, Long sharingPostId, Long giverId, Long receiverId, Long chatRoomId, ParticipationStatus status, LocalDateTime createdAt, LocalDateTime modifiedAt) {
         this.participationId = participationId;
         this.sharingPostId = sharingPostId;
         this.giverId = giverId;
         this.receiverId = receiverId;
+        this.chatRoomId = chatRoomId;
         this.status = status;
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
     }
 
-    public static ParticipationResponseDto from(Participation participation){
+
+
+    public static ParticipationResponseDto from(Participation participation, ChatRoom chatRoom){
         return new ParticipationResponseDto(
                 participation.getId(),
                 participation.getPost().getId(),
                 participation.getGiver().getId(),
                 participation.getPost().getWriter().getId(),
+                chatRoom.getId(),
                 participation.getStatus(),
                 participation.getCreatedAt(),
                 participation.getModifiedAt()

--- a/src/main/java/com/carpBread/shareEatIt/domain/participation/service/ParticipationService.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/participation/service/ParticipationService.java
@@ -1,5 +1,6 @@
 package com.carpBread.shareEatIt.domain.participation.service;
 
+import com.carpBread.shareEatIt.domain.chat.entity.ChatRoom;
 import com.carpBread.shareEatIt.domain.chat.service.ChatRoomService;
 import com.carpBread.shareEatIt.domain.member.entity.Member;
 import com.carpBread.shareEatIt.domain.notice.dto.NoticeCreateDto;
@@ -69,10 +70,10 @@ public class ParticipationService {
         Participation savedParticipation = participationRepository.save(participation);
 
         // 채팅방 생성
-        chatRoomService.createChatRoom(receiver, participation.getId());
+        ChatRoom savedChatRoom = chatRoomService.createChatRoom(receiver, participation.getId());
 
         // 응답 DTO 생성
-        ParticipationResponseDto responseDto = ParticipationResponseDto.from(savedParticipation);
+        ParticipationResponseDto responseDto = ParticipationResponseDto.from(savedParticipation, savedChatRoom);
         return responseDto;
 
     }


### PR DESCRIPTION
## 변경 사항
 - #9 
 - 참여 생성시 성공 응답값에 생성된 채팅방Id 포함하도록 수정

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 , 폴더명 , 파일 경로 수정
- [ ] 파일 혹은 폴더 삭제


### 반영 브랜치
ex) feat/participation -> develop

### 테스트 결과

### ETC
- 