### PR TITLE
fix: 소켓 통신 에러 해결 (순환참조, 풀링 방식 전환 문제)

### DIFF
--- a/src/main/java/com/carpBread/shareEatIt/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/chat/controller/ChatController.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -28,6 +29,7 @@ public class ChatController {
 
     /* 채팅 - 메시지 전달*/
     @MessageMapping("/chat/message/{chatRoomId}")  // app/chat/message/{chatRoomId} 로 메세지 발송
+    @SendTo("/topic/chatRoom/{chatRoomId}") // 동적으로 chatRoomId에 맞는 경로로 메시지 발송하도록 명확히 지정 (아니면 순환 참조 문제 발생 가능)
     public ChatMessageResponseDto sendMessage(@Payload ChatMessageRequestDto requestDto) {
         ChatMessageResponseDto responseDto = chatMessageService.saveMessage(requestDto);
         messagingTemplate.convertAndSend("/topic/chatRoom/"+ responseDto.getChatRoomId(), responseDto);

--- a/src/main/java/com/carpBread/shareEatIt/global/config/WebSocketConfig.java
+++ b/src/main/java/com/carpBread/shareEatIt/global/config/WebSocketConfig.java
@@ -24,7 +24,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.addEndpoint("/ws")
 //                .setAllowedOrigins("https://jiangxy.github.io", "http://localhost:3000", "http://54.180.228.54", "https://api.shareeat.r-e.kr", "ws://localhost:8080", "wss://api.shareeat.r-e.kr", "https://shareeatit.netlify.app/")
                 .setAllowedOriginPatterns("*")  // CORS 설정 - 모든 도메인에서 오는 요청 허용
-                .withSockJS();
+                .withSockJS()
+                .setHeartbeatTime(30000);  // 클라이언트-서버 가 30초마다 핑/퐁 메시지를 주고 받도록 설정
     }
 
     @Override


### PR DESCRIPTION
## 변경 사항
 - #47 
-  **메시지 전달 경로 순환참조 문제 해결**
    - @Send 애노테이션으로 메시지 전달 경로 동적으로 명확히 지정
 - **일정 시간 이후 소켓 통신이 http 통신인 풀링 방식으로 바뀌는 문제 해결**
   - nginx 설정 파일에서 시간 수정 (60s -> 3600s)
   - WebSocketConfig 파일에서 30초마다 핑퐁 메시지 주고 받도록 설정


## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 , 폴더명 , 파일 경로 수정
- [ ] 파일 혹은 폴더 삭제


### 반영 브랜치
ex) feat/chatting -> develop

### 테스트 결과

### ETC
- 