### PR TITLE
🔧 fix : OAuth2 로그인 시 세션 삭제 및 연속 로그인 가능하게끔 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.3.4'
 	id 'io.spring.dependency-management' version '1.1.6'
-	// id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com.carpBread'
@@ -41,8 +40,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 
@@ -60,8 +60,6 @@ dependencies {
 	implementation 'com.amazonaws:aws-java-sdk-s3'
 
 	testImplementation "io.findify:s3mock_2.13:0.2.6"
-//	testImplementation "org.testcontainers:localstack:1.18.0"
-//	testImplementation 'org.testcontainers:junit-jupiter'
 
 	// redis - for logout
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
@@ -80,7 +78,6 @@ dependencies {
 	implementation 'org.geotools:gt-main:27.0'         // GeoTools 메인 라이브러리
 	implementation 'org.geotools:gt-cql:27.0'          // GeoTools의 필터 및 쿼리 기능
 	implementation 'org.geotools:gt-epsg-hsql:27.0'    // 좌표 변환을 위한 EPSG 데이터베이스
-//	implementation 'org.locationtech.jts:jts-core:1.18.2'
 	implementation 'org.hibernate:hibernate-spatial:6.2.6.Final' // Hibernate Spatial for JPA support
 
 	// websocket

--- a/src/main/generated/com/carpBread/shareEatIt/domain/auth/oauth2/entity/QOAuth2Token.java
+++ b/src/main/generated/com/carpBread/shareEatIt/domain/auth/oauth2/entity/QOAuth2Token.java
@@ -1,0 +1,63 @@
+package com.carpBread.shareEatIt.domain.auth.oauth2.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QOAuth2Token is a Querydsl query type for OAuth2Token
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QOAuth2Token extends EntityPathBase<OAuth2Token> {
+
+    private static final long serialVersionUID = 1429533503L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QOAuth2Token oAuth2Token = new QOAuth2Token("oAuth2Token");
+
+    public final com.carpBread.shareEatIt.global.entity.QBaseEntity _super = new com.carpBread.shareEatIt.global.entity.QBaseEntity(this);
+
+    public final StringPath accessToken = createString("accessToken");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.carpBread.shareEatIt.domain.member.entity.QMember member;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final EnumPath<com.carpBread.shareEatIt.domain.auth.LoginProvider> provider = createEnum("provider", com.carpBread.shareEatIt.domain.auth.LoginProvider.class);
+
+    public QOAuth2Token(String variable) {
+        this(OAuth2Token.class, forVariable(variable), INITS);
+    }
+
+    public QOAuth2Token(Path<? extends OAuth2Token> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QOAuth2Token(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QOAuth2Token(PathMetadata metadata, PathInits inits) {
+        this(OAuth2Token.class, metadata, inits);
+    }
+
+    public QOAuth2Token(Class<? extends OAuth2Token> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new com.carpBread.shareEatIt.domain.member.entity.QMember(forProperty("member")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/carpBread/shareEatIt/domain/chat/entity/QChatRoom.java
+++ b/src/main/generated/com/carpBread/shareEatIt/domain/chat/entity/QChatRoom.java
@@ -1,0 +1,61 @@
+package com.carpBread.shareEatIt.domain.chat.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QChatRoom is a Querydsl query type for ChatRoom
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QChatRoom extends EntityPathBase<ChatRoom> {
+
+    private static final long serialVersionUID = 1189609799L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QChatRoom chatRoom = new QChatRoom("chatRoom");
+
+    public final com.carpBread.shareEatIt.global.entity.QBaseEntity _super = new com.carpBread.shareEatIt.global.entity.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final com.carpBread.shareEatIt.domain.participation.entity.QParticipation participation;
+
+    public final EnumPath<ChatRoomStatus> status = createEnum("status", ChatRoomStatus.class);
+
+    public QChatRoom(String variable) {
+        this(ChatRoom.class, forVariable(variable), INITS);
+    }
+
+    public QChatRoom(Path<? extends ChatRoom> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QChatRoom(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QChatRoom(PathMetadata metadata, PathInits inits) {
+        this(ChatRoom.class, metadata, inits);
+    }
+
+    public QChatRoom(Class<? extends ChatRoom> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.participation = inits.isInitialized("participation") ? new com.carpBread.shareEatIt.domain.participation.entity.QParticipation(forProperty("participation"), inits.get("participation")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/carpBread/shareEatIt/domain/member/entity/QKeywords.java
+++ b/src/main/generated/com/carpBread/shareEatIt/domain/member/entity/QKeywords.java
@@ -1,0 +1,55 @@
+package com.carpBread.shareEatIt.domain.member.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QKeywords is a Querydsl query type for Keywords
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QKeywords extends EntityPathBase<Keywords> {
+
+    private static final long serialVersionUID = 713180192L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QKeywords keywords = new QKeywords("keywords");
+
+    public final BooleanPath avail = createBoolean("avail");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath keyword = createString("keyword");
+
+    public final QMember member;
+
+    public QKeywords(String variable) {
+        this(Keywords.class, forVariable(variable), INITS);
+    }
+
+    public QKeywords(Path<? extends Keywords> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QKeywords(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QKeywords(PathMetadata metadata, PathInits inits) {
+        this(Keywords.class, metadata, inits);
+    }
+
+    public QKeywords(Class<? extends Keywords> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new QMember(forProperty("member")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/carpBread/shareEatIt/domain/member/entity/QMember.java
+++ b/src/main/generated/com/carpBread/shareEatIt/domain/member/entity/QMember.java
@@ -1,0 +1,76 @@
+package com.carpBread.shareEatIt.domain.member.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMember is a Querydsl query type for Member
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMember extends EntityPathBase<Member> {
+
+    private static final long serialVersionUID = 1098962064L;
+
+    public static final QMember member = new QMember("member1");
+
+    public final com.carpBread.shareEatIt.global.entity.QBaseEntity _super = new com.carpBread.shareEatIt.global.entity.QBaseEntity(this);
+
+    public final NumberPath<Long> accessId = createNumber("accessId", Long.class);
+
+    public final StringPath accessToken = createString("accessToken");
+
+    public final StringPath addressDetail = createString("addressDetail");
+
+    public final StringPath addressSt = createString("addressSt");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final StringPath email = createString("email");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final BooleanPath isKeywordAvail = createBoolean("isKeywordAvail");
+
+    public final BooleanPath isNoticeAvail = createBoolean("isNoticeAvail");
+
+    public final ListPath<Keywords, QKeywords> keywordsList = this.<Keywords, QKeywords>createList("keywordsList", Keywords.class, QKeywords.class, PathInits.DIRECT2);
+
+    public final ComparablePath<org.locationtech.jts.geom.Point> locationPoint = createComparable("locationPoint", org.locationtech.jts.geom.Point.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final StringPath nickname = createString("nickname");
+
+    public final StringPath password = createString("password");
+
+    public final StringPath profileImgUrl = createString("profileImgUrl");
+
+    public final EnumPath<Provider> provider = createEnum("provider", Provider.class);
+
+    public final StringPath refreshToken = createString("refreshToken");
+
+    public final StringPath username = createString("username");
+
+    public QMember(String variable) {
+        super(Member.class, forVariable(variable));
+    }
+
+    public QMember(Path<? extends Member> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QMember(PathMetadata metadata) {
+        super(Member.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/carpBread/shareEatIt/domain/notice/entity/QNotice.java
+++ b/src/main/generated/com/carpBread/shareEatIt/domain/notice/entity/QNotice.java
@@ -1,0 +1,67 @@
+package com.carpBread.shareEatIt.domain.notice.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QNotice is a Querydsl query type for Notice
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QNotice extends EntityPathBase<Notice> {
+
+    private static final long serialVersionUID = 1969858700L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QNotice notice = new QNotice("notice");
+
+    public final com.carpBread.shareEatIt.global.entity.QBaseEntity _super = new com.carpBread.shareEatIt.global.entity.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final BooleanPath isRead = createBoolean("isRead");
+
+    public final com.carpBread.shareEatIt.domain.member.entity.QMember member;
+
+    public final StringPath message = createString("message");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final StringPath title = createString("title");
+
+    public final EnumPath<NoticeType> type = createEnum("type", NoticeType.class);
+
+    public QNotice(String variable) {
+        this(Notice.class, forVariable(variable), INITS);
+    }
+
+    public QNotice(Path<? extends Notice> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QNotice(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QNotice(PathMetadata metadata, PathInits inits) {
+        this(Notice.class, metadata, inits);
+    }
+
+    public QNotice(Class<? extends Notice> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new com.carpBread.shareEatIt.domain.member.entity.QMember(forProperty("member")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/carpBread/shareEatIt/domain/participation/entity/QGratitudeSticker.java
+++ b/src/main/generated/com/carpBread/shareEatIt/domain/participation/entity/QGratitudeSticker.java
@@ -1,0 +1,70 @@
+package com.carpBread.shareEatIt.domain.participation.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QGratitudeSticker is a Querydsl query type for GratitudeSticker
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QGratitudeSticker extends EntityPathBase<GratitudeSticker> {
+
+    private static final long serialVersionUID = -1347164497L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QGratitudeSticker gratitudeSticker = new QGratitudeSticker("gratitudeSticker");
+
+    public final com.carpBread.shareEatIt.global.entity.QBaseEntity _super = new com.carpBread.shareEatIt.global.entity.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final com.carpBread.shareEatIt.domain.member.entity.QMember giver;
+
+    public final EnumPath<GratitudeType> gratitudeType = createEnum("gratitudeType", GratitudeType.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final QParticipation participation;
+
+    public final com.carpBread.shareEatIt.domain.sharingPost.entity.QSharingPost post;
+
+    public final com.carpBread.shareEatIt.domain.member.entity.QMember reviewer;
+
+    public QGratitudeSticker(String variable) {
+        this(GratitudeSticker.class, forVariable(variable), INITS);
+    }
+
+    public QGratitudeSticker(Path<? extends GratitudeSticker> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QGratitudeSticker(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QGratitudeSticker(PathMetadata metadata, PathInits inits) {
+        this(GratitudeSticker.class, metadata, inits);
+    }
+
+    public QGratitudeSticker(Class<? extends GratitudeSticker> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.giver = inits.isInitialized("giver") ? new com.carpBread.shareEatIt.domain.member.entity.QMember(forProperty("giver")) : null;
+        this.participation = inits.isInitialized("participation") ? new QParticipation(forProperty("participation"), inits.get("participation")) : null;
+        this.post = inits.isInitialized("post") ? new com.carpBread.shareEatIt.domain.sharingPost.entity.QSharingPost(forProperty("post"), inits.get("post")) : null;
+        this.reviewer = inits.isInitialized("reviewer") ? new com.carpBread.shareEatIt.domain.member.entity.QMember(forProperty("reviewer")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/carpBread/shareEatIt/domain/participation/entity/QParticipation.java
+++ b/src/main/generated/com/carpBread/shareEatIt/domain/participation/entity/QParticipation.java
@@ -1,0 +1,73 @@
+package com.carpBread.shareEatIt.domain.participation.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QParticipation is a Querydsl query type for Participation
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QParticipation extends EntityPathBase<Participation> {
+
+    private static final long serialVersionUID = -1409782686L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QParticipation participation = new QParticipation("participation");
+
+    public final com.carpBread.shareEatIt.global.entity.QBaseEntity _super = new com.carpBread.shareEatIt.global.entity.QBaseEntity(this);
+
+    public final DateTimePath<java.time.LocalDateTime> completedAt = createDateTime("completedAt", java.time.LocalDateTime.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final com.carpBread.shareEatIt.domain.member.entity.QMember giver;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final BooleanPath isGiverInChat = createBoolean("isGiverInChat");
+
+    public final BooleanPath isReceiverInChat = createBoolean("isReceiverInChat");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final com.carpBread.shareEatIt.domain.sharingPost.entity.QSharingPost post;
+
+    public final com.carpBread.shareEatIt.domain.member.entity.QMember receiver;
+
+    public final EnumPath<ParticipationStatus> status = createEnum("status", ParticipationStatus.class);
+
+    public QParticipation(String variable) {
+        this(Participation.class, forVariable(variable), INITS);
+    }
+
+    public QParticipation(Path<? extends Participation> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QParticipation(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QParticipation(PathMetadata metadata, PathInits inits) {
+        this(Participation.class, metadata, inits);
+    }
+
+    public QParticipation(Class<? extends Participation> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.giver = inits.isInitialized("giver") ? new com.carpBread.shareEatIt.domain.member.entity.QMember(forProperty("giver")) : null;
+        this.post = inits.isInitialized("post") ? new com.carpBread.shareEatIt.domain.sharingPost.entity.QSharingPost(forProperty("post"), inits.get("post")) : null;
+        this.receiver = inits.isInitialized("receiver") ? new com.carpBread.shareEatIt.domain.member.entity.QMember(forProperty("receiver")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/carpBread/shareEatIt/domain/report/entity/QReport.java
+++ b/src/main/generated/com/carpBread/shareEatIt/domain/report/entity/QReport.java
@@ -1,0 +1,76 @@
+package com.carpBread.shareEatIt.domain.report.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QReport is a Querydsl query type for Report
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QReport extends EntityPathBase<Report> {
+
+    private static final long serialVersionUID = 1588122692L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QReport report = new QReport("report");
+
+    public final com.carpBread.shareEatIt.global.entity.QBaseEntity _super = new com.carpBread.shareEatIt.global.entity.QBaseEntity(this);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath imgUrl = createString("imgUrl");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final com.carpBread.shareEatIt.domain.sharingPost.entity.QSharingPost post;
+
+    public final com.carpBread.shareEatIt.domain.member.entity.QMember reporter;
+
+    public final StringPath response = createString("response");
+
+    public final DateTimePath<java.time.LocalDateTime> responseAt = createDateTime("responseAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> reviewedAt = createDateTime("reviewedAt", java.time.LocalDateTime.class);
+
+    public final EnumPath<ReportStatus> status = createEnum("status", ReportStatus.class);
+
+    public final StringPath title = createString("title");
+
+    public QReport(String variable) {
+        this(Report.class, forVariable(variable), INITS);
+    }
+
+    public QReport(Path<? extends Report> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QReport(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QReport(PathMetadata metadata, PathInits inits) {
+        this(Report.class, metadata, inits);
+    }
+
+    public QReport(Class<? extends Report> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.post = inits.isInitialized("post") ? new com.carpBread.shareEatIt.domain.sharingPost.entity.QSharingPost(forProperty("post"), inits.get("post")) : null;
+        this.reporter = inits.isInitialized("reporter") ? new com.carpBread.shareEatIt.domain.member.entity.QMember(forProperty("reporter")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/carpBread/shareEatIt/domain/sharingPost/entity/QPostImgUrl.java
+++ b/src/main/generated/com/carpBread/shareEatIt/domain/sharingPost/entity/QPostImgUrl.java
@@ -1,0 +1,55 @@
+package com.carpBread.shareEatIt.domain.sharingPost.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QPostImgUrl is a Querydsl query type for PostImgUrl
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPostImgUrl extends EntityPathBase<PostImgUrl> {
+
+    private static final long serialVersionUID = 1064405446L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QPostImgUrl postImgUrl = new QPostImgUrl("postImgUrl");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Integer> imgOrder = createNumber("imgOrder", Integer.class);
+
+    public final QSharingPost post;
+
+    public final StringPath url = createString("url");
+
+    public QPostImgUrl(String variable) {
+        this(PostImgUrl.class, forVariable(variable), INITS);
+    }
+
+    public QPostImgUrl(Path<? extends PostImgUrl> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QPostImgUrl(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QPostImgUrl(PathMetadata metadata, PathInits inits) {
+        this(PostImgUrl.class, metadata, inits);
+    }
+
+    public QPostImgUrl(Class<? extends PostImgUrl> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.post = inits.isInitialized("post") ? new QSharingPost(forProperty("post"), inits.get("post")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/carpBread/shareEatIt/domain/sharingPost/entity/QSharingPost.java
+++ b/src/main/generated/com/carpBread/shareEatIt/domain/sharingPost/entity/QSharingPost.java
@@ -1,0 +1,93 @@
+package com.carpBread.shareEatIt.domain.sharingPost.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QSharingPost is a Querydsl query type for SharingPost
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QSharingPost extends EntityPathBase<SharingPost> {
+
+    private static final long serialVersionUID = 559118466L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QSharingPost sharingPost = new QSharingPost("sharingPost");
+
+    public final com.carpBread.shareEatIt.global.entity.QBaseEntity _super = new com.carpBread.shareEatIt.global.entity.QBaseEntity(this);
+
+    public final StringPath addressDetail = createString("addressDetail");
+
+    public final StringPath addressSt = createString("addressSt");
+
+    public final EnumPath<PostCategory> category = createEnum("category", PostCategory.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final StringPath description = createString("description");
+
+    public final DateTimePath<java.time.LocalDateTime> endAt = createDateTime("endAt", java.time.LocalDateTime.class);
+
+    public final DatePath<java.time.LocalDate> expDate = createDate("expDate", java.time.LocalDate.class);
+
+    public final StringPath foodName = createString("foodName");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final BooleanPath isFinished = createBoolean("isFinished");
+
+    public final StringPath kakaoLocationCode = createString("kakaoLocationCode");
+
+    public final ComparablePath<org.locationtech.jts.geom.Point> locationPoint = createComparable("locationPoint", org.locationtech.jts.geom.Point.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final BooleanPath noticed = createBoolean("noticed");
+
+    public final ListPath<com.carpBread.shareEatIt.domain.participation.entity.Participation, com.carpBread.shareEatIt.domain.participation.entity.QParticipation> participationList = this.<com.carpBread.shareEatIt.domain.participation.entity.Participation, com.carpBread.shareEatIt.domain.participation.entity.QParticipation>createList("participationList", com.carpBread.shareEatIt.domain.participation.entity.Participation.class, com.carpBread.shareEatIt.domain.participation.entity.QParticipation.class, PathInits.DIRECT2);
+
+    public final ListPath<PostImgUrl, QPostImgUrl> postImgUrlList = this.<PostImgUrl, QPostImgUrl>createList("postImgUrlList", PostImgUrl.class, QPostImgUrl.class, PathInits.DIRECT2);
+
+    public final EnumPath<PostType> postType = createEnum("postType", PostType.class);
+
+    public final DatePath<java.time.LocalDate> purchaseDate = createDate("purchaseDate", java.time.LocalDate.class);
+
+    public final EnumPath<PostStatus> status = createEnum("status", PostStatus.class);
+
+    public final StringPath title = createString("title");
+
+    public final com.carpBread.shareEatIt.domain.member.entity.QMember writer;
+
+    public QSharingPost(String variable) {
+        this(SharingPost.class, forVariable(variable), INITS);
+    }
+
+    public QSharingPost(Path<? extends SharingPost> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QSharingPost(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QSharingPost(PathMetadata metadata, PathInits inits) {
+        this(SharingPost.class, metadata, inits);
+    }
+
+    public QSharingPost(Class<? extends SharingPost> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.writer = inits.isInitialized("writer") ? new com.carpBread.shareEatIt.domain.member.entity.QMember(forProperty("writer")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/carpBread/shareEatIt/global/entity/QBaseEntity.java
+++ b/src/main/generated/com/carpBread/shareEatIt/global/entity/QBaseEntity.java
@@ -1,0 +1,39 @@
+package com.carpBread.shareEatIt.global.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseEntity is a Querydsl query type for BaseEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseEntity extends EntityPathBase<BaseEntity> {
+
+    private static final long serialVersionUID = -218508065L;
+
+    public static final QBaseEntity baseEntity = new QBaseEntity("baseEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = createDateTime("modifiedAt", java.time.LocalDateTime.class);
+
+    public QBaseEntity(String variable) {
+        super(BaseEntity.class, forVariable(variable));
+    }
+
+    public QBaseEntity(Path<? extends BaseEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseEntity(PathMetadata metadata) {
+        super(BaseEntity.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/carpBread/shareEatIt/domain/auth/oauth2/handler/OAuth2LogoutHandler.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/auth/oauth2/handler/OAuth2LogoutHandler.java
@@ -14,6 +14,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
@@ -93,6 +94,8 @@ public class OAuth2LogoutHandler implements LogoutHandler {
                 googleLogout(member);
                 break;
         }
+
+        response.setStatus(HttpStatus.OK.value());
 
     }
 

--- a/src/main/java/com/carpBread/shareEatIt/domain/auth/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/auth/oauth2/service/CustomOAuth2UserService.java
@@ -60,6 +60,8 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         Boolean isJoined = signUpIfNotExists(oAuth2Attribute,accessToken, LoginProvider.toEnum(registrationId));
         attributesMap.put("is_new_member",isJoined);
 
+        System.out.println(oAuth2User.getAttributes());
+
         // 5. OAuth2User 구현 객체 리턴
         return new DefaultOAuth2User(
                 // authorization을 set으로 생성하여 추가가 삭제가 불가하고 단일 객체만 생성 가능

--- a/src/main/java/com/carpBread/shareEatIt/global/config/SecurityConfig.java
+++ b/src/main/java/com/carpBread/shareEatIt/global/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.carpBread.shareEatIt.domain.auth.oauth2.handler.OAuth2FailureHandler;
 import com.carpBread.shareEatIt.domain.auth.oauth2.handler.OAuth2LogoutHandler;
 import com.carpBread.shareEatIt.domain.auth.oauth2.handler.OAuth2SuccessHandler;
 import com.carpBread.shareEatIt.domain.auth.oauth2.service.CustomOAuth2UserService;
+import com.carpBread.shareEatIt.global.entity.HttpCookieOAuth2AuthorizationRequestRepository;
 import com.carpBread.shareEatIt.global.jwt.JWTFilter;
 import com.carpBread.shareEatIt.global.jwt.JWTUtils;
 import com.carpBread.shareEatIt.domain.member.repository.MemberRepository;
@@ -22,6 +23,8 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -50,6 +53,7 @@ public class SecurityConfig {
 
     // handler
     private final JWTCustomExceptionHandler jwtCustomExceptionHandler;
+    private final AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository;
 
     // oauth2
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
@@ -87,23 +91,37 @@ public class SecurityConfig {
                     .failureHandler(authenticationFailureHandler)
             )
             .httpBasic(AbstractHttpConfigurer::disable)
-            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .sessionManagement(session -> session
+                            .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            )
             .authorizeHttpRequests(request-> request
                     .requestMatchers(AUTH_WHITELIST).permitAll()  // 채팅 엔드포인트 인증 제외함
                     .anyRequest().hasRole("MEMBER")
             )
             .oauth2Login(oauth2 ->oauth2
+                    .authorizationEndpoint(endpoint -> endpoint
+                            .authorizationRequestRepository(authorizationRequestRepository)
+                    )
                     .successHandler(oAuth2SuccessHandler)
                     .failureHandler(oAuth2FailureHandler)
-                    .userInfoEndpoint(endpoint-> endpoint.userService(oAuth2UserService))
+                    .userInfoEndpoint(endpoint-> endpoint
+                            .userService(oAuth2UserService))
             )
             .logout(logout -> logout
                     .addLogoutHandler(oAuth2LogoutHandler)
                     .logoutUrl("/logout")
+                    .invalidateHttpSession(true) // 세션 무효화
+                    .deleteCookies("JSESSIONID")
+                    .clearAuthentication(true)
             );
         ;
         return http.build();
 
+    }
+
+    @Bean
+    public AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository(){
+        return new HttpCookieOAuth2AuthorizationRequestRepository();
     }
 
     /* 비밀번호 암호화 해시 함수 bean 등록 */

--- a/src/main/java/com/carpBread/shareEatIt/global/entity/CookieUtils.java
+++ b/src/main/java/com/carpBread/shareEatIt/global/entity/CookieUtils.java
@@ -1,0 +1,58 @@
+package com.carpBread.shareEatIt.global.entity;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.util.SerializationUtils;
+
+import java.util.Base64;
+import java.util.Optional;
+
+public class CookieUtils {
+
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    return Optional.of(cookie);
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie: cookies) {
+                if (cookie.getName().equals(name)) {
+                    cookie.setValue("");
+                    cookie.setPath("/");
+                    cookie.setMaxAge(0);
+                    response.addCookie(cookie);
+                }
+            }
+        }
+    }
+
+    public static String serialize(Object object) {
+        return Base64.getUrlEncoder()
+                .encodeToString(SerializationUtils.serialize(object));
+    }
+
+    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+        return cls.cast(SerializationUtils.deserialize(
+                Base64.getUrlDecoder().decode(cookie.getValue())));
+    }
+}

--- a/src/main/java/com/carpBread/shareEatIt/global/entity/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/carpBread/shareEatIt/global/entity/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,54 @@
+package com.carpBread.shareEatIt.global.entity;
+
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HttpCookieOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+    public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+    private static final int cookieExpireSeconds = 20;
+
+    /** cookie 에 저장되어있던 authorizationRequest 들을 가져온다 authorizationUri, authorizationGrantType, responseType, clientId, redirectUri, scopes, additionalParameters */
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        return CookieUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+                .map(cookie -> CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class))
+                .orElse(null);
+    }
+
+    /** 플랫폼으로 보내기 위한 Request 를 `oauth2_auth_request` 라는  cookie 에 저장 한다 authorizationUri, authorizationGrantType, responseType, clientId, redirectUri, scopes, additionalParameters */
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            removeAuthorizationRequest(request, response);
+            return;
+        }
+
+        CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtils.serialize(authorizationRequest), cookieExpireSeconds);
+
+        String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+        if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+            CookieUtils.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds);
+        }
+    }
+
+    /** remove 를 재정의 해서 cookie 를 가져오고 remove 는 successHandler 또는 failureHandler 에서 할 수 있도록 한다 */
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request, HttpServletResponse response) {
+        return this.loadAuthorizationRequest(request);
+    }
+
+    /**
+     * 사용자 정보를 다 가지고 온 뒤 이제 리다이렉트를 하면 기존에 남아있던 쿠키들을 제거해주기 위해 사용된다
+     *  OAuth2AuthorizationRequest 와 클라이언트에서 파리미터로 요청한 redirect_uri 가 된다
+     * */
+    public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+        CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+    }
+}


### PR DESCRIPTION
## ✏️ 변경 사항
 - HttpCookieOAuth2AuthorizationRequestRepository 추가 -> oauth2 로그인 정보 세션 방식에서 쿠키로 변경
 - build.gradle 주석 삭제
 
## 🔢 Issue 번호
 - 

## 🔎 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 , 폴더명 , 파일 경로 수정
- [ ] 파일 혹은 폴더 삭제


### 🪵반영 브랜치
feat/auth -> develop

### 📑 테스트 결과

naver accesstoken 만료 시간인 1시간 이후 다시 로그인화면창이 뜨는 것을 확인.

![네이버이전](https://github.com/user-attachments/assets/336daa46-433f-47e9-b243-f249b7134c64)
![네이버 이후](https://github.com/user-attachments/assets/610ebea2-c213-4081-97d0-20ca9c5bc769)


### 📚 ETC
- 
![네이버oauth2유효기간](https://github.com/user-attachments/assets/cb4775cb-3a3c-4b67-932f-9d108aece077)

