### PR TITLE
🔧 fix : 나눔 통계 조회 시 잘못된 periodType에 대한 예외처리 추가

### DIFF
--- a/src/main/java/com/carpBread/shareEatIt/domain/sharingPost/service/StatsService.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/sharingPost/service/StatsService.java
@@ -9,6 +9,9 @@ import com.carpBread.shareEatIt.global.entity.Period;
 import com.carpBread.shareEatIt.domain.sharingPost.entity.PostStatus;
 import com.carpBread.shareEatIt.domain.sharingPost.entity.SharingPost;
 import com.carpBread.shareEatIt.domain.sharingPost.repository.SharingPostQuerydslRepository;
+import com.carpBread.shareEatIt.global.exception.CustomException;
+import com.carpBread.shareEatIt.global.exception.CustomExceptionStatus;
+import com.carpBread.shareEatIt.global.exception.Domain;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -49,6 +52,14 @@ public class StatsService {
             period=ago.getYear()+"-"+ago.getMonthValue()+"-"+ago.getDayOfMonth()
                     +" ~ "
                     +now.getYear()+"-"+now.getMonthValue()+"-"+now.getDayOfMonth();
+        }else {
+            throw new CustomException(
+                    CustomExceptionStatus.INVALID_ENUM_VALUE,
+                    "올바르지 않은 PeriodType ENUM 값입니다",
+                    this.getClass().getSimpleName(),
+                    periodType,
+                    Domain.SHARING_POST
+            );
         }
 
         // 2. post 조회


### PR DESCRIPTION
## ✏️ 변경 사항
 - StatsService 내 나눔 통계 조회 시 periodType에 잘못된 값(ex - 'year') 이 입력되었을 경우 예외처리 추가
 
## 🔢 Issue 번호
 - 

## 🔎 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 , 폴더명 , 파일 경로 수정
- [ ] 파일 혹은 폴더 삭제


### 🪵반영 브랜치
feat/sharingpost -> develop

### 📑 테스트 결과
![image](https://github.com/user-attachments/assets/5fb4c863-e851-4e92-83ff-471d488dca4f)

### 📚 ETC
- 
