### PR TITLE
🔧 fix : 참여 통계 조회 시 잘못된 periodType에 대한 예외처리

### DIFF
--- a/src/main/java/com/carpBread/shareEatIt/domain/participation/service/ParticipationStatsService.java
+++ b/src/main/java/com/carpBread/shareEatIt/domain/participation/service/ParticipationStatsService.java
@@ -8,6 +8,9 @@ import com.carpBread.shareEatIt.domain.participation.entity.Participation;
 import com.carpBread.shareEatIt.domain.participation.repository.ParticipationQuerydslRepository;
 import com.carpBread.shareEatIt.domain.sharingPost.dto.response.stats.RankResponseDto;
 import com.carpBread.shareEatIt.global.entity.Period;
+import com.carpBread.shareEatIt.global.exception.CustomException;
+import com.carpBread.shareEatIt.global.exception.CustomExceptionStatus;
+import com.carpBread.shareEatIt.global.exception.Domain;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -48,6 +51,14 @@ public class ParticipationStatsService {
             period=ago.getYear()+"-"+ago.getMonthValue()+"-"+ago.getDayOfMonth()
                     +" ~ "
                     +now.getYear()+"-"+now.getMonthValue()+"-"+now.getDayOfMonth();
+        }else {
+            throw new CustomException(
+                    CustomExceptionStatus.INVALID_ENUM_VALUE,
+                    "올바르지 않은 PeriodType ENUM 값입니다",
+                    this.getClass().getSimpleName(),
+                    periodType,
+                    Domain.PARTICIPATION
+            );
         }
 
         // 2. paricipation 조회


### PR DESCRIPTION
## ✏️ 변경 사항
 - ParticipationStatsService 내 참여 통계 조회 시 잘못된 PeriodType ENUM 값이 들어왔을 때 예외처리
 
## 🔢 Issue 번호
 - 

## 🔎 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 , 폴더명 , 파일 경로 수정
- [ ] 파일 혹은 폴더 삭제


### 🪵반영 브랜치
 feat/participation -> develop

### 📑 테스트 결과
![image](https://github.com/user-attachments/assets/071eab57-1bf2-4a54-a975-84e0738f5301)

### 📚 ETC
- 
