### PR TITLE
feat: RunTimeException 예외 커스텀

### DIFF
--- a/src/main/java/com/carpBread/shareEatIt/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/carpBread/shareEatIt/global/exception/GlobalExceptionHandler.java
@@ -1,39 +1,78 @@
 package com.carpBread.shareEatIt.global.exception;
 
-import com.carpBread.shareEatIt.global.response.ApiResponse;
 import io.sentry.Sentry;
+import io.sentry.protocol.SentryId;
+import io.sentry.spring.jakarta.EnableSentry;
+import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.transaction.TransactionSystemException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.time.DateTimeException;
+import java.util.ConcurrentModificationException;
+import java.util.concurrent.TimeoutException;
+
+import static org.springframework.http.HttpStatus.*;
 
 /* 어플리케이션 내 발생하는 런타임 예외 핸들러 */
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
     @Value("${sentry.dsn}")
     private String dsn;
 
+//    @PostConstruct
+//    public void init() {
+//        // Sentry 초기화 설정
+//        Sentry.init(options -> {
+//            options.setDsn(dsn);
+//            options.setBeforeSend((event, hint) -> {
+//                System.out.println("Sentry Event: " + event.getExtras());
+//                return event;
+//            });
+//        });
+//
+//        if (Sentry.isEnabled()) {
+//            log.info("✅ Sentry initialized with DSN: {}", dsn);
+//        } else {
+//            log.error("❌ Sentry 초기화 실패! DSN 확인 필요");
+//        }
+//        System.out.println("Sentry initialized");
+//    }
+
     /* CustomException 핸들러 */
     @ExceptionHandler(CustomException.class)
-    public ApiResponse<CustomExceptionResponseDto> handleAppException(CustomException e, HttpServletRequest request){
+    public ResponseEntity<CustomExceptionResponseDto> handleAppException(CustomException e, HttpServletRequest request){
+
+        // Sentry 초기화 설정
+        Sentry.init(options -> {
+            options.setDsn(dsn);
+            options.setTracesSampleRate(1.0);  // 샘플링 비율 설정
+        });
+
         // response dto 생성
         CustomExceptionResponseDto responseDto= new CustomExceptionResponseDto(e);
 
-        // Sentry 시스템에 전송
-        Sentry.init(options -> {
-            options.setDsn(
-                    dsn
-//                    "https://1c2ac0504036a173f428c1d39c271693@o4508679774142464.ingest.us.sentry.io/4508679775584256"
-            );
-        });
-
+        // sentry에 전송할 내용
         Sentry.configureScope(scope ->{
-            scope.setTransaction(request.getRequestURI());
+            scope.setTransaction(request.getMethod() + " " + request.getRequestURI());
             scope.setExtra("file_path", responseDto.getFilePath());
             scope.setExtra("exception_status", responseDto.getExceptionStatus());
-            scope.setExtra("message",responseDto.getMessage());
+            scope.setExtra("message", responseDto.getMessage());
             scope.setExtra("timestamp", String.valueOf(responseDto.getTimestamp()));
             scope.setExtra("causation", responseDto.getCausation());
             scope.setExtra("request_method", request.getMethod());
@@ -42,8 +81,149 @@ public class GlobalExceptionHandler {
             Sentry.captureException(e);
         });
 
+
+
+        System.out.println("커스텀 핸들러 실행됨");
+
         // controller에서와 달리 exception 발생 시에는 각 HttpStatus가 다르므로, status() 함수 사용을 위해 ResponseEntity를 사용하였습니다.
-        return new ApiResponse<>(e.getExceptionStatus().getStatus().value(),"Exception Occur",responseDto);
+        return ResponseEntity.status(e.getExceptionStatus().getStatus()).body(responseDto);
     }
-    
+
+    /*-----------------------------------------------------------------------------------------------------*/
+
+    /**
+     * 메서드 주석: 상태코드 - 상태코드명 - {예외클래스명}
+     * {예외클래스명}이 없는 경우 - 여러 예외 클래스 공통 메서드
+     * {예외클래스명}이 있는 경우 - 특정 예외 클래스 커스텀 메서드
+     */
+
+    /* 400 Bad Request 핸들러 */
+    @ExceptionHandler({NullPointerException.class, IllegalArgumentException.class, IndexOutOfBoundsException.class,
+            MissingServletRequestParameterException.class, MethodArgumentNotValidException.class, HttpMessageNotReadableException.class,
+            HttpMediaTypeNotSupportedException.class, DataIntegrityViolationException.class, DateTimeException.class})
+    public ResponseEntity<UncheckedExceptionResponseDto> handleBadRequestException(RuntimeException e, HttpServletRequest request) {
+        // responseDto 생성
+        UncheckedExceptionResponseDto responseDto = new UncheckedExceptionResponseDto(e);
+
+        // sentry에 전송할 내용 추가
+        sentryConfigure(e, request, responseDto);
+        return ResponseEntity.status(BAD_REQUEST).body(responseDto);
+    }
+
+    /* 400 Bad Request  - MethodArgumentTypeMismatchException 핸들러 */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<UncheckedExceptionResponseDto> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e, HttpServletRequest request) {
+        // responseDto 생성
+        String errorMessage = String.format(
+                "요청한 파라미터 '%s'에 잘못된 값 '%s'이(가) 전달되었습니다.", e.getName(), e.getValue());
+        UncheckedExceptionResponseDto responseDto = new UncheckedExceptionResponseDto(e, errorMessage);
+
+        // sentry에 전송할 내용 추가
+        sentryConfigure(e, request, responseDto);
+        return ResponseEntity.status(BAD_REQUEST).body(responseDto);
+    }
+
+    /* 401 Unauthorized 핸들러 */
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<UncheckedExceptionResponseDto> handleUnauthorizedException(RuntimeException e, HttpServletRequest request) {
+        // responseDto 생성
+        UncheckedExceptionResponseDto responseDto = new UncheckedExceptionResponseDto(e);
+
+        // sentry에 전송할 내용 추가
+        sentryConfigure(e, request, responseDto);
+        return ResponseEntity.status(UNAUTHORIZED).body(responseDto);
+    }
+
+    /* 403 Forbidden 핸들러 */
+    @ExceptionHandler(SecurityException.class)
+    public ResponseEntity<UncheckedExceptionResponseDto> handleForbiddenException(RuntimeException e, HttpServletRequest request) {
+        // responseDto 생성
+        UncheckedExceptionResponseDto responseDto = new UncheckedExceptionResponseDto(e);
+
+        // sentry에 전송할 내용 추가
+        sentryConfigure(e, request, responseDto);
+        return ResponseEntity.status(FORBIDDEN).body(responseDto);
+    }
+
+    /* 405 Method Not Allowed -  HttpRequestMethodNotSupportedException 핸들러 */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<UncheckedExceptionResponseDto> handleHttpRequestMethodNotSupportedException(RuntimeException e, HttpServletRequest request) {
+        // responseDto 생성
+        String errorMessage = String.format(
+                "지원되지 않는 HTTP 메서드입니다. 요청된 메서드: %s", request.getMethod());
+        UncheckedExceptionResponseDto responseDto = new UncheckedExceptionResponseDto(e, errorMessage);
+
+        // sentry에 전송할 내용 추가
+        sentryConfigure(e, request, responseDto);
+        return ResponseEntity.status(METHOD_NOT_ALLOWED).body(responseDto);
+    }
+
+    /* 408  Request Timeout - TimeoutException 핸들러 */
+    @ExceptionHandler(TimeoutException.class)
+    public ResponseEntity<UncheckedExceptionResponseDto> handleTimeoutException(RuntimeException e, HttpServletRequest request) {
+        // responseDto 생성
+        String errorMessage = "시스템 작업을 시간을 초과했습니다.";
+        UncheckedExceptionResponseDto responseDto = new UncheckedExceptionResponseDto(e, errorMessage);
+
+        // sentry에 전송할 내용 추가
+        sentryConfigure(e, request, responseDto);
+        return ResponseEntity.status(REQUEST_TIMEOUT).body(responseDto);
+    }
+
+    /* 409 Conflict- ConcurrentModificationException 핸들러 */
+    @ExceptionHandler(ConcurrentModificationException.class)
+    public ResponseEntity<UncheckedExceptionResponseDto> handleConcurrentModificationException(RuntimeException e, HttpServletRequest request) {
+        // responseDto 생성
+        String errorMessage = "동시 처리 오류가 발생했습니다. ";
+        UncheckedExceptionResponseDto responseDto = new UncheckedExceptionResponseDto(e, errorMessage);
+
+        // sentry에 전송할 내용 추가
+        sentryConfigure(e, request, responseDto);
+        return ResponseEntity.status(CONFLICT).body(responseDto);
+    }
+
+    /* 500  Internal Server Error 핸들러 */
+    @ExceptionHandler(TransactionSystemException.class)
+    public ResponseEntity<UncheckedExceptionResponseDto> handleInternalServerErrorException(RuntimeException e, HttpServletRequest request) {
+        // responseDto 생성
+        String errorMessage = "서버에러 - 시스템에서 예기치 않은 오류가 발생했습니다";
+        UncheckedExceptionResponseDto responseDto = new UncheckedExceptionResponseDto(e, errorMessage);
+
+        // sentry에 전송할 내용 추가
+        sentryConfigure(e, request, responseDto);
+        return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(responseDto);
+    }
+
+    /*---------------------------------------------------------------------------------------------*/
+
+    // sentry 전달 내용 설정 메서드
+    private void sentryConfigure(RuntimeException e, HttpServletRequest request, UncheckedExceptionResponseDto responseDto) {
+        String method = request.getMethod();
+        String requestURI = request.getRequestURI();
+        StackTraceElement[] stackTrace = e.getStackTrace();
+        StackTraceElement element = stackTrace.length > 0 ? stackTrace[0] : null;  // 예외가 없을 경우 대비
+
+        // Sentry 초기화 설정
+        Sentry.init(options -> {
+            options.setDsn(dsn);
+            options.setTracesSampleRate(1.0);  // 샘플링 비율 설정
+        });
+
+        // sentry에 전송할 내용
+        Sentry.withScope(scope -> {
+            scope.setTransaction(method + " 런타임" + requestURI);
+            // 추가 정보
+            scope.setExtra("file_path", element.getClassName());
+            scope.setExtra("exception_status", responseDto.getExceptionStatus());
+            scope.setExtra("message", responseDto.getMessage());
+            scope.setExtra("timestamp", String.valueOf(responseDto.getTimestamp()));
+            scope.setExtra("causation", responseDto.getCause());
+            scope.setExtra("request_method", method);
+            scope.setExtra("request_uri", requestURI);
+            // 예외를 sentry로 전송
+            Sentry.captureException(e);
+        });
+
+    }
 }
+

--- a/src/main/java/com/carpBread/shareEatIt/global/exception/UncheckedExceptionResponseDto.java
+++ b/src/main/java/com/carpBread/shareEatIt/global/exception/UncheckedExceptionResponseDto.java
@@ -1,0 +1,28 @@
+package com.carpBread.shareEatIt.global.exception;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class UncheckedExceptionResponseDto {
+
+    private final String exceptionStatus;
+    private final String message;
+    private final String cause;
+    private final LocalDateTime timestamp;
+
+    public UncheckedExceptionResponseDto(Exception e) {
+        this.exceptionStatus = e.getClass().getSimpleName();  // 에러명
+        this.message = e.getMessage();
+        this.cause = String.valueOf(e.getCause());
+        this.timestamp = LocalDateTime.now();
+    }
+
+    public UncheckedExceptionResponseDto(Exception e, String message) {
+        this.exceptionStatus = e.getClass().getSimpleName();  // 에러명
+        this.message = message;
+        this.cause = String.valueOf(e.getCause());
+        this.timestamp = LocalDateTime.now();
+    }
+}


### PR DESCRIPTION
## ✏️ 변경 사항
 - RunTimeException 예외 응답 커스텀
 - sentry에 전송할 예외 핸들링
 
## 🔢 Issue 번호
 - #232 

## 🔎 PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 , 폴더명 , 파일 경로 수정
- [ ] 파일 혹은 폴더 삭제


### 🪵반영 브랜치
ex) feat/exception-> develop

### 📑 테스트 결과
![image](https://github.com/user-attachments/assets/7cca6a3a-f62a-44bb-bda8-26d3bc9a2caf)
![image](https://github.com/user-attachments/assets/6946fc07-5525-481f-a8bb-f0c7c961aa8e)

### 📚 ETC
- postman으로 테스트할 때 중복으로 에러메시지가 전송됨
(핸들링한 메시지, 핸들링 하지 않은 메시지)
- 초기화 로직을 메소드 밖에 작성할 경우 sentry 메시지가 전송되지 않는 문제 존재
